### PR TITLE
🏷️ [Types] Export library types

### DIFF
--- a/.changeset/four-terms-give.md
+++ b/.changeset/four-terms-give.md
@@ -1,0 +1,5 @@
+---
+'earwurm': patch
+---
+
+Export types for LibraryEntry and LibraryKeys.

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,8 @@ export type {
   ManagerState,
   ManagerEventMap,
   ManagerConfig,
+  LibraryEntry,
+  LibraryKeys,
   StackState,
   StackEventMap,
   StackConfig,


### PR DESCRIPTION
Now exporting `LibraryEntry` and `LibraryKeys`.