### PR TITLE
🐛 [Earwurn] Various fixes

### DIFF
--- a/.changeset/light-cats-sniff.md
+++ b/.changeset/light-cats-sniff.md
@@ -1,0 +1,5 @@
+---
+'earwurm': patch
+---
+
+Solves a `this` binding issue by converting a `Stack` method to an arrow function.

--- a/.changeset/quiet-years-fly.md
+++ b/.changeset/quiet-years-fly.md
@@ -1,0 +1,5 @@
+---
+'earwurm': patch
+---
+
+Removed some `console.log` calls.

--- a/.changeset/slow-horses-flash.md
+++ b/.changeset/slow-horses-flash.md
@@ -1,0 +1,5 @@
+---
+'earwurm': patch
+---
+
+Bumps `emitten` to `0.2.0` to solve a `super > accessor` bug.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "earwurm",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "earwurm",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "license": "ISC",
       "dependencies": {
-        "emitten": "^0.1.0"
+        "emitten": "^0.2.0"
       },
       "devDependencies": {
         "@changesets/changelog-github": "^0.4.8",
@@ -1947,9 +1947,9 @@
       }
     },
     "node_modules/emitten": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/emitten/-/emitten-0.1.0.tgz",
-      "integrity": "sha512-ORSBzFnaeNbSKhLprxiuFb6bBtHwiIqOak7/it3kNgU3TNjz9Y2OXmxe1hFWPFF/9YQvi45hDhVYXtITTltxzg==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/emitten/-/emitten-0.2.0.tgz",
+      "integrity": "sha512-bJHQMDD1wjlVAHuLX26i729lXBsyZXXbfEEfkc6VsF0m1na4dee4u+G+8OD8onj9HpkSoS7y9Zy3PlEUo98AIw==",
       "engines": {
         "node": ">=18.0.0"
       }
@@ -7195,9 +7195,9 @@
       "dev": true
     },
     "emitten": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/emitten/-/emitten-0.1.0.tgz",
-      "integrity": "sha512-ORSBzFnaeNbSKhLprxiuFb6bBtHwiIqOak7/it3kNgU3TNjz9Y2OXmxe1hFWPFF/9YQvi45hDhVYXtITTltxzg=="
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/emitten/-/emitten-0.2.0.tgz",
+      "integrity": "sha512-bJHQMDD1wjlVAHuLX26i729lXBsyZXXbfEEfkc6VsF0m1na4dee4u+G+8OD8onj9HpkSoS7y9Zy3PlEUo98AIw=="
     },
     "emoji-regex": {
       "version": "8.0.0",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "release": "npm run build && changeset publish"
   },
   "dependencies": {
-    "emitten": "^0.1.0"
+    "emitten": "^0.2.0"
   },
   "devDependencies": {
     "@changesets/changelog-github": "^0.4.8",

--- a/src/Stack.ts
+++ b/src/Stack.ts
@@ -167,7 +167,7 @@ export class Stack extends EmittenProtected<StackEventMap> {
       return scratchBuffer(this.context);
     });
 
-    this.#setStateFromQueue();
+    this.#handleStateFromQueue();
 
     return result;
   }
@@ -177,7 +177,7 @@ export class Stack extends EmittenProtected<StackEventMap> {
       fadeMs: secToMs(this.#fadeSec),
     });
 
-    newSound.on('statechange', this.#setStateFromQueue);
+    newSound.on('statechange', this.#handleStateFromQueue);
     newSound.once('ended', this.#handleSoundEnded);
 
     const newQueue = [...this.#queue, newSound];
@@ -205,9 +205,9 @@ export class Stack extends EmittenProtected<StackEventMap> {
     this.emit('statechange', value);
   }
 
-  #setStateFromQueue() {
+  #handleStateFromQueue = () => {
     this.#setState(this.playing ? 'playing' : 'idle');
-  }
+  };
 
   #handleSoundEnded = (event?: SoundEndedEvent) => {
     // TODO: `event` should never be `undefined`.

--- a/src/helpers/unlock-audio-context.ts
+++ b/src/helpers/unlock-audio-context.ts
@@ -34,8 +34,6 @@ export function unlockAudioContext(
       source.disconnect();
 
       INTERACTION_EVENTS.forEach((type) => {
-        console.log('INTERACTION_EVENTS > remove > type', type);
-
         document.removeEventListener(type, unlock, {capture: true});
       });
 
@@ -47,8 +45,6 @@ export function unlockAudioContext(
   }
 
   INTERACTION_EVENTS.forEach((type) => {
-    console.log('INTERACTION_EVENTS > add > type', type);
-
     document.addEventListener(type, unlock, {
       capture: true,
       once: true,


### PR DESCRIPTION
**This PR:**
- Exports both the `LibraryEntry` and `LibraryKeys` types.
- Removed some `console.log` calls that got missed.
- Solves a `this` binding issue by converting a `Stack` method to an arrow function.
- Bumps `emitten` to `0.2.0` to solve a `super > accessor` bug.