### PR TITLE
🧰 [Dependency] Bump `emitten` to `v0.3.0`

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -14,7 +14,7 @@
     "no-console": "off",
     "prettier/prettier": ["error"],
     "@typescript-eslint/explicit-function-return-type": "off",
-    "@typescript-eslint/no-dynamic-delete": "off",
+    "@typescript-eslint/method-signature-style": "off",
     "@typescript-eslint/strict-boolean-expressions": "off"
   }
 }

--- a/docs/api.md
+++ b/docs/api.md
@@ -106,11 +106,11 @@ manager.activeEvents;
 // Returns the current `AudioContext > state`. This may trigger
 // immediately upon `new Earwurm()` if the `AudioContext` is
 // “unlocked” right away.
-(event: ManagerEventMap['statechange'], listener: (state?: ManagerState) => void)
+(event: 'statechange', listener: (state: ManagerState) => void)
 
 // Event called whenever an error is occured on the `AudioContext`.
 // This could be a result of: failed to resume, failed to close.
-(event: ManagerEventMap['error'], listener: (message?: CombinedErrorMessage) => void)
+(event: 'error', listener: (error: CombinedErrorMessage) => void)
 ```
 
 **Static members:**
@@ -228,11 +228,11 @@ soundStack.activeEvents;
 // the `Stack`. As sounds cycle through their various states, the
 // `Stack` will determine if any `Sound` is currently `playing`.
 // Possible `StackState` values are: `idle`, `loading`, `playing`.
-(event: StackEventMap['statechange'], listener: (state?: StackState) => void)
+(event: 'statechange', listener: (state: StackState) => void)
 
 // Event called whenever an error is occured on the `Stack`.
 // This could be a result of: failed to load the `path`.
-(event: StackEventMap['error'], listener: ({id, message}?: StackError) => void)
+(event: 'error', listener: ({id, message}: StackError) => void)
 ```
 
 **Static members:**
@@ -321,13 +321,13 @@ sound.duration;
 // Event called whenever `Sound > state` is changed.
 // Possible `SoundState` values are:
 // `created`, `playing`, `paused`, and `stopping`.
-(event: SoundEventMap['statechange'], listener: (state?: SoundState) => void)
+(event: 'statechange', listener: (state: SoundState) => void)
 
 // Event called on the audio `source` node whenenver
 // a `Sound` reaches either it’s “end duration”,
 // or has been stopped / removed from the `Stack`.
 // This will NOT get called each time a “loop” repeats.
-(event: SoundEventMap['ended'], listener: ({id, source}?: SoundEndedEvent) => void)
+(event: 'ended', listener: ({id, source}: SoundEndedEvent) => void)
 ```
 
 ## Events API
@@ -343,17 +343,17 @@ All 3 components of `Earwurm` _(`manager`, `stack` and `sound`)_ each have “ev
 const component = new Earwurm();
 
 // Register an event listener for a specified event.
-component.on(event, listener: (value?) => void);
-
-// Remove any previously registered event listener.
-component.off(event, listener: (value?) => void);
+component.on(event, listener: (value) => void);
 
 // Register an event listener that will remove itself
 // after only a single execution.
-component.once(event, listener: (value?) => void);
+component.once(event, listener: (value) => void);
+
+// Remove any previously registered event listener.
+component.off(event, listener: (value) => void);
 
 // Register an event listener that will return the
 // corresponding `.off()` function, allowing for
 // easier removal of anonymous functions.
-const registered = component.disposable(event, listener: (value?) => void);
+const registered = component.on(event, listener: (value) => void);
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,34 +1,37 @@
 {
   "name": "earwurm",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "earwurm",
-      "version": "0.0.2",
+      "version": "0.0.3",
       "license": "ISC",
       "dependencies": {
-        "emitten": "^0.2.0"
+        "emitten": "^0.3.0"
       },
       "devDependencies": {
         "@changesets/changelog-github": "^0.4.8",
         "@changesets/cli": "^2.26.0",
         "@types/node": "^18.11.18",
         "@typescript-eslint/eslint-plugin": "^5.49.0",
-        "eslint": "^8.32.0",
+        "eslint": "^8.33.0",
         "eslint-config-prettier": "^8.6.0",
         "eslint-config-standard-with-typescript": "^33.0.0",
         "eslint-plugin-import": "^2.27.5",
         "eslint-plugin-n": "^15.6.1",
         "eslint-plugin-prettier": "^4.2.1",
         "eslint-plugin-promise": "^6.1.1",
-        "typescript": "^4.9.4",
+        "typescript": "^4.9.5",
         "vite": "^4.0.4",
         "vite-plugin-dts": "^1.7.1"
       },
       "engines": {
         "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "emitten": "^0.3.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -820,15 +823,15 @@
       }
     },
     "node_modules/@microsoft/api-extractor": {
-      "version": "7.34.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.34.0.tgz",
-      "integrity": "sha512-U9opcYpFrN0eIVunEx90SDSYzmjgO2mEVbttHwtJBjOHUhK2cY2QykH8uiBnJuVtuBvHVCdEFUGt6i/8LVexYA==",
+      "version": "7.34.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.34.1.tgz",
+      "integrity": "sha512-ZMMfMJuhdW0m0Mr7J+4rfM9ZWUJTQnHVpTGWL7Jo05Ai3lPKdONTdnC9Nz39T+EBV4FDWFr9BvOd4IvBkyKqmQ==",
       "dev": true,
       "dependencies": {
-        "@microsoft/api-extractor-model": "7.26.0",
+        "@microsoft/api-extractor-model": "7.26.1",
         "@microsoft/tsdoc": "0.14.2",
         "@microsoft/tsdoc-config": "~0.16.1",
-        "@rushstack/node-core-library": "3.53.3",
+        "@rushstack/node-core-library": "3.54.0",
         "@rushstack/rig-package": "0.3.17",
         "@rushstack/ts-command-line": "4.13.1",
         "colors": "~1.2.1",
@@ -843,15 +846,92 @@
       }
     },
     "node_modules/@microsoft/api-extractor-model": {
-      "version": "7.26.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor-model/-/api-extractor-model-7.26.0.tgz",
-      "integrity": "sha512-iUlscM9a3/scqgaL+sipTYsfbkF/frrZhdYWXm5+zEVMW6QlP5jDV6cYNeIEIdMeGSbzk1yxpBjyeBDAZQLdyA==",
+      "version": "7.26.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor-model/-/api-extractor-model-7.26.1.tgz",
+      "integrity": "sha512-d/IwUIFDXYwecx2H0dVqv7lBMwwXNY6RN7TBFhBx+CCsDuYM6R5/o4qfRtUyyKzpNZMBJyuPP56XAhcBJeXiwg==",
       "dev": true,
       "dependencies": {
         "@microsoft/tsdoc": "0.14.2",
         "@microsoft/tsdoc-config": "~0.16.1",
-        "@rushstack/node-core-library": "3.53.3"
+        "@rushstack/node-core-library": "3.54.0"
       }
+    },
+    "node_modules/@microsoft/api-extractor-model/node_modules/@rushstack/node-core-library": {
+      "version": "3.54.0",
+      "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-3.54.0.tgz",
+      "integrity": "sha512-QOfjrilrhVbJx5ahDhMzJ+izWJU+EFIbU9N2P1a3PSenQgIthWl68DoCLQUjsHqfsA4YxlABFfuYKoPV/GlTOg==",
+      "dev": true,
+      "dependencies": {
+        "colors": "~1.2.1",
+        "fs-extra": "~7.0.1",
+        "import-lazy": "~4.0.0",
+        "jju": "~1.4.0",
+        "resolve": "~1.22.1",
+        "semver": "~7.3.0",
+        "z-schema": "~5.0.2"
+      },
+      "peerDependencies": {
+        "@types/node": "^12.20.24"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@microsoft/api-extractor-model/node_modules/@types/node": {
+      "version": "12.20.55",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
+      "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==",
+      "dev": true,
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/@microsoft/api-extractor-model/node_modules/semver": {
+      "version": "7.3.8",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@microsoft/api-extractor/node_modules/@rushstack/node-core-library": {
+      "version": "3.54.0",
+      "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-3.54.0.tgz",
+      "integrity": "sha512-QOfjrilrhVbJx5ahDhMzJ+izWJU+EFIbU9N2P1a3PSenQgIthWl68DoCLQUjsHqfsA4YxlABFfuYKoPV/GlTOg==",
+      "dev": true,
+      "dependencies": {
+        "colors": "~1.2.1",
+        "fs-extra": "~7.0.1",
+        "import-lazy": "~4.0.0",
+        "jju": "~1.4.0",
+        "resolve": "~1.22.1",
+        "semver": "~7.3.0",
+        "z-schema": "~5.0.2"
+      },
+      "peerDependencies": {
+        "@types/node": "^12.20.24"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@microsoft/api-extractor/node_modules/@types/node": {
+      "version": "12.20.55",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
+      "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==",
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "node_modules/@microsoft/api-extractor/node_modules/semver": {
       "version": "7.3.8",
@@ -967,55 +1047,6 @@
         "rollup": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@rushstack/node-core-library": {
-      "version": "3.53.3",
-      "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-3.53.3.tgz",
-      "integrity": "sha512-H0+T5koi5MFhJUd5ND3dI3bwLhvlABetARl78L3lWftJVQEPyzcgTStvTTRiIM5mCltyTM8VYm6BuCtNUuxD0Q==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "12.20.24",
-        "colors": "~1.2.1",
-        "fs-extra": "~7.0.1",
-        "import-lazy": "~4.0.0",
-        "jju": "~1.4.0",
-        "resolve": "~1.17.0",
-        "semver": "~7.3.0",
-        "z-schema": "~5.0.2"
-      }
-    },
-    "node_modules/@rushstack/node-core-library/node_modules/@types/node": {
-      "version": "12.20.24",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.24.tgz",
-      "integrity": "sha512-yxDeaQIAJlMav7fH5AQqPH1u8YIuhYJXYBzxaQ4PifsU0GDO38MSdmEDeRlIxrKbC6NbEaaEHDanWb+y30U8SQ==",
-      "dev": true
-    },
-    "node_modules/@rushstack/node-core-library/node_modules/resolve": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
-      "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
-      "dev": true,
-      "dependencies": {
-        "path-parse": "^1.0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/@rushstack/node-core-library/node_modules/semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/@rushstack/rig-package": {
@@ -1947,9 +1978,9 @@
       }
     },
     "node_modules/emitten": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/emitten/-/emitten-0.2.0.tgz",
-      "integrity": "sha512-bJHQMDD1wjlVAHuLX26i729lXBsyZXXbfEEfkc6VsF0m1na4dee4u+G+8OD8onj9HpkSoS7y9Zy3PlEUo98AIw==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/emitten/-/emitten-0.3.0.tgz",
+      "integrity": "sha512-dTpzx0/KiNIsTIczZHLnY0d7ZfYifzzKtAvJ5qLfoIoGSsfcuUsErOwGncOydGJVIBt/MxCq+SVWMTYukGUPng==",
       "engines": {
         "node": ">=18.0.0"
       }
@@ -2124,9 +2155,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.32.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.32.0.tgz",
-      "integrity": "sha512-nETVXpnthqKPFyuY2FNjz/bEd6nbosRgKbkgS/y1C7LJop96gYHWpiguLecMHQ2XCPxn77DS0P+68WzG6vkZSQ==",
+      "version": "8.33.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.33.0.tgz",
+      "integrity": "sha512-WjOpFQgKK8VrCnAtl8We0SUOy/oVZ5NHykyMiagV1M9r8IFpIJX7DduK6n1mpfhlG7T1NLWm2SuD8QB7KFySaA==",
       "dev": true,
       "dependencies": {
         "@eslint/eslintrc": "^1.4.1",
@@ -3079,9 +3110,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "13.19.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.19.0.tgz",
-      "integrity": "sha512-dkQ957uSRWHw7CFXLUtUHQI3g3aWApYhfNR2O6jn/907riyTYKVBmxYVROkBcY614FSSeSJh7Xm7SrUWCxvJMQ==",
+      "version": "13.20.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.20.0.tgz",
+      "integrity": "sha512-Qg5QtVkCy/kv3FUSlu4ukeZDVf9ee0iXLAUYX13gbR17bnejFTzr4iS9bY7kwCf1NztRNm1t91fjOiyx4CSwPQ==",
       "dev": true,
       "dependencies": {
         "type-fest": "^0.20.2"
@@ -4668,9 +4699,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "3.11.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.11.0.tgz",
-      "integrity": "sha512-+uWPPkpWQ2H3Qi7sNBcRfhhHJyUNgBYhG4wKe5wuGRj2m55kpo+0p5jubKNBjQODyPe6tSBE3tNpdDwEisQvAQ==",
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.12.0.tgz",
+      "integrity": "sha512-4MZ8kA2HNYahIjz63rzrMMRvDqQDeS9LoriJvMuV0V6zIGysP36e9t4yObUfwdT9h/szXoHQideICftcdZklWg==",
       "dev": true,
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -5382,9 +5413,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.9.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
-      "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -5517,6 +5548,51 @@
         "vite": ">=2.9.0"
       }
     },
+    "node_modules/vite-plugin-dts/node_modules/@rushstack/node-core-library": {
+      "version": "3.54.0",
+      "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-3.54.0.tgz",
+      "integrity": "sha512-QOfjrilrhVbJx5ahDhMzJ+izWJU+EFIbU9N2P1a3PSenQgIthWl68DoCLQUjsHqfsA4YxlABFfuYKoPV/GlTOg==",
+      "dev": true,
+      "dependencies": {
+        "colors": "~1.2.1",
+        "fs-extra": "~7.0.1",
+        "import-lazy": "~4.0.0",
+        "jju": "~1.4.0",
+        "resolve": "~1.22.1",
+        "semver": "~7.3.0",
+        "z-schema": "~5.0.2"
+      },
+      "peerDependencies": {
+        "@types/node": "^12.20.24"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-plugin-dts/node_modules/@rushstack/node-core-library/node_modules/fs-extra": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
+    },
+    "node_modules/vite-plugin-dts/node_modules/@types/node": {
+      "version": "12.20.55",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
+      "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==",
+      "dev": true,
+      "optional": true,
+      "peer": true
+    },
     "node_modules/vite-plugin-dts/node_modules/fs-extra": {
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
@@ -5531,7 +5607,7 @@
         "node": ">=12"
       }
     },
-    "node_modules/vite-plugin-dts/node_modules/jsonfile": {
+    "node_modules/vite-plugin-dts/node_modules/fs-extra/node_modules/jsonfile": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
       "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
@@ -5543,13 +5619,28 @@
         "graceful-fs": "^4.1.6"
       }
     },
-    "node_modules/vite-plugin-dts/node_modules/universalify": {
+    "node_modules/vite-plugin-dts/node_modules/fs-extra/node_modules/universalify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
       "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
       "dev": true,
       "engines": {
         "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/vite-plugin-dts/node_modules/semver": {
+      "version": "7.3.8",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/wcwidth": {
@@ -6358,15 +6449,15 @@
       }
     },
     "@microsoft/api-extractor": {
-      "version": "7.34.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.34.0.tgz",
-      "integrity": "sha512-U9opcYpFrN0eIVunEx90SDSYzmjgO2mEVbttHwtJBjOHUhK2cY2QykH8uiBnJuVtuBvHVCdEFUGt6i/8LVexYA==",
+      "version": "7.34.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.34.1.tgz",
+      "integrity": "sha512-ZMMfMJuhdW0m0Mr7J+4rfM9ZWUJTQnHVpTGWL7Jo05Ai3lPKdONTdnC9Nz39T+EBV4FDWFr9BvOd4IvBkyKqmQ==",
       "dev": true,
       "requires": {
-        "@microsoft/api-extractor-model": "7.26.0",
+        "@microsoft/api-extractor-model": "7.26.1",
         "@microsoft/tsdoc": "0.14.2",
         "@microsoft/tsdoc-config": "~0.16.1",
-        "@rushstack/node-core-library": "3.53.3",
+        "@rushstack/node-core-library": "3.54.0",
         "@rushstack/rig-package": "0.3.17",
         "@rushstack/ts-command-line": "4.13.1",
         "colors": "~1.2.1",
@@ -6377,6 +6468,29 @@
         "typescript": "~4.8.4"
       },
       "dependencies": {
+        "@rushstack/node-core-library": {
+          "version": "3.54.0",
+          "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-3.54.0.tgz",
+          "integrity": "sha512-QOfjrilrhVbJx5ahDhMzJ+izWJU+EFIbU9N2P1a3PSenQgIthWl68DoCLQUjsHqfsA4YxlABFfuYKoPV/GlTOg==",
+          "dev": true,
+          "requires": {
+            "colors": "~1.2.1",
+            "fs-extra": "~7.0.1",
+            "import-lazy": "~4.0.0",
+            "jju": "~1.4.0",
+            "resolve": "~1.22.1",
+            "semver": "~7.3.0",
+            "z-schema": "~5.0.2"
+          }
+        },
+        "@types/node": {
+          "version": "12.20.55",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
+          "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==",
+          "dev": true,
+          "optional": true,
+          "peer": true
+        },
         "semver": {
           "version": "7.3.8",
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
@@ -6395,14 +6509,48 @@
       }
     },
     "@microsoft/api-extractor-model": {
-      "version": "7.26.0",
-      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor-model/-/api-extractor-model-7.26.0.tgz",
-      "integrity": "sha512-iUlscM9a3/scqgaL+sipTYsfbkF/frrZhdYWXm5+zEVMW6QlP5jDV6cYNeIEIdMeGSbzk1yxpBjyeBDAZQLdyA==",
+      "version": "7.26.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor-model/-/api-extractor-model-7.26.1.tgz",
+      "integrity": "sha512-d/IwUIFDXYwecx2H0dVqv7lBMwwXNY6RN7TBFhBx+CCsDuYM6R5/o4qfRtUyyKzpNZMBJyuPP56XAhcBJeXiwg==",
       "dev": true,
       "requires": {
         "@microsoft/tsdoc": "0.14.2",
         "@microsoft/tsdoc-config": "~0.16.1",
-        "@rushstack/node-core-library": "3.53.3"
+        "@rushstack/node-core-library": "3.54.0"
+      },
+      "dependencies": {
+        "@rushstack/node-core-library": {
+          "version": "3.54.0",
+          "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-3.54.0.tgz",
+          "integrity": "sha512-QOfjrilrhVbJx5ahDhMzJ+izWJU+EFIbU9N2P1a3PSenQgIthWl68DoCLQUjsHqfsA4YxlABFfuYKoPV/GlTOg==",
+          "dev": true,
+          "requires": {
+            "colors": "~1.2.1",
+            "fs-extra": "~7.0.1",
+            "import-lazy": "~4.0.0",
+            "jju": "~1.4.0",
+            "resolve": "~1.22.1",
+            "semver": "~7.3.0",
+            "z-schema": "~5.0.2"
+          }
+        },
+        "@types/node": {
+          "version": "12.20.55",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
+          "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==",
+          "dev": true,
+          "optional": true,
+          "peer": true
+        },
+        "semver": {
+          "version": "7.3.8",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        }
       }
     },
     "@microsoft/tsdoc": {
@@ -6470,48 +6618,6 @@
         "@types/estree": "^1.0.0",
         "estree-walker": "^2.0.2",
         "picomatch": "^2.3.1"
-      }
-    },
-    "@rushstack/node-core-library": {
-      "version": "3.53.3",
-      "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-3.53.3.tgz",
-      "integrity": "sha512-H0+T5koi5MFhJUd5ND3dI3bwLhvlABetARl78L3lWftJVQEPyzcgTStvTTRiIM5mCltyTM8VYm6BuCtNUuxD0Q==",
-      "dev": true,
-      "requires": {
-        "@types/node": "12.20.24",
-        "colors": "~1.2.1",
-        "fs-extra": "~7.0.1",
-        "import-lazy": "~4.0.0",
-        "jju": "~1.4.0",
-        "resolve": "~1.17.0",
-        "semver": "~7.3.0",
-        "z-schema": "~5.0.2"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "12.20.24",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.24.tgz",
-          "integrity": "sha512-yxDeaQIAJlMav7fH5AQqPH1u8YIuhYJXYBzxaQ4PifsU0GDO38MSdmEDeRlIxrKbC6NbEaaEHDanWb+y30U8SQ==",
-          "dev": true
-        },
-        "resolve": {
-          "version": "1.17.0",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
-          "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
-          "dev": true,
-          "requires": {
-            "path-parse": "^1.0.6"
-          }
-        },
-        "semver": {
-          "version": "7.3.8",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        }
       }
     },
     "@rushstack/rig-package": {
@@ -7195,9 +7301,9 @@
       "dev": true
     },
     "emitten": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/emitten/-/emitten-0.2.0.tgz",
-      "integrity": "sha512-bJHQMDD1wjlVAHuLX26i729lXBsyZXXbfEEfkc6VsF0m1na4dee4u+G+8OD8onj9HpkSoS7y9Zy3PlEUo98AIw=="
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/emitten/-/emitten-0.3.0.tgz",
+      "integrity": "sha512-dTpzx0/KiNIsTIczZHLnY0d7ZfYifzzKtAvJ5qLfoIoGSsfcuUsErOwGncOydGJVIBt/MxCq+SVWMTYukGUPng=="
     },
     "emoji-regex": {
       "version": "8.0.0",
@@ -7338,9 +7444,9 @@
       "dev": true
     },
     "eslint": {
-      "version": "8.32.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.32.0.tgz",
-      "integrity": "sha512-nETVXpnthqKPFyuY2FNjz/bEd6nbosRgKbkgS/y1C7LJop96gYHWpiguLecMHQ2XCPxn77DS0P+68WzG6vkZSQ==",
+      "version": "8.33.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.33.0.tgz",
+      "integrity": "sha512-WjOpFQgKK8VrCnAtl8We0SUOy/oVZ5NHykyMiagV1M9r8IFpIJX7DduK6n1mpfhlG7T1NLWm2SuD8QB7KFySaA==",
       "dev": true,
       "requires": {
         "@eslint/eslintrc": "^1.4.1",
@@ -8032,9 +8138,9 @@
       }
     },
     "globals": {
-      "version": "13.19.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.19.0.tgz",
-      "integrity": "sha512-dkQ957uSRWHw7CFXLUtUHQI3g3aWApYhfNR2O6jn/907riyTYKVBmxYVROkBcY614FSSeSJh7Xm7SrUWCxvJMQ==",
+      "version": "13.20.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.20.0.tgz",
+      "integrity": "sha512-Qg5QtVkCy/kv3FUSlu4ukeZDVf9ee0iXLAUYX13gbR17bnejFTzr4iS9bY7kwCf1NztRNm1t91fjOiyx4CSwPQ==",
       "dev": true,
       "requires": {
         "type-fest": "^0.20.2"
@@ -9159,9 +9265,9 @@
       }
     },
     "rollup": {
-      "version": "3.11.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.11.0.tgz",
-      "integrity": "sha512-+uWPPkpWQ2H3Qi7sNBcRfhhHJyUNgBYhG4wKe5wuGRj2m55kpo+0p5jubKNBjQODyPe6tSBE3tNpdDwEisQvAQ==",
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.12.0.tgz",
+      "integrity": "sha512-4MZ8kA2HNYahIjz63rzrMMRvDqQDeS9LoriJvMuV0V6zIGysP36e9t4yObUfwdT9h/szXoHQideICftcdZklWg==",
       "dev": true,
       "requires": {
         "fsevents": "~2.3.2"
@@ -9708,9 +9814,9 @@
       }
     },
     "typescript": {
-      "version": "4.9.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
-      "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true
     },
     "unbox-primitive": {
@@ -9785,6 +9891,42 @@
         "ts-morph": "^16.0.0"
       },
       "dependencies": {
+        "@rushstack/node-core-library": {
+          "version": "3.54.0",
+          "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-3.54.0.tgz",
+          "integrity": "sha512-QOfjrilrhVbJx5ahDhMzJ+izWJU+EFIbU9N2P1a3PSenQgIthWl68DoCLQUjsHqfsA4YxlABFfuYKoPV/GlTOg==",
+          "dev": true,
+          "requires": {
+            "colors": "~1.2.1",
+            "fs-extra": "~7.0.1",
+            "import-lazy": "~4.0.0",
+            "jju": "~1.4.0",
+            "resolve": "~1.22.1",
+            "semver": "~7.3.0",
+            "z-schema": "~5.0.2"
+          },
+          "dependencies": {
+            "fs-extra": {
+              "version": "7.0.1",
+              "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+              "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+              "dev": true,
+              "requires": {
+                "graceful-fs": "^4.1.2",
+                "jsonfile": "^4.0.0",
+                "universalify": "^0.1.0"
+              }
+            }
+          }
+        },
+        "@types/node": {
+          "version": "12.20.55",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
+          "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==",
+          "dev": true,
+          "optional": true,
+          "peer": true
+        },
         "fs-extra": {
           "version": "10.1.0",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
@@ -9794,23 +9936,34 @@
             "graceful-fs": "^4.2.0",
             "jsonfile": "^6.0.1",
             "universalify": "^2.0.0"
+          },
+          "dependencies": {
+            "jsonfile": {
+              "version": "6.1.0",
+              "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+              "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+              "dev": true,
+              "requires": {
+                "graceful-fs": "^4.1.6",
+                "universalify": "^2.0.0"
+              }
+            },
+            "universalify": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+              "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+              "dev": true
+            }
           }
         },
-        "jsonfile": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-          "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+        "semver": {
+          "version": "7.3.8",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.6",
-            "universalify": "^2.0.0"
+            "lru-cache": "^6.0.0"
           }
-        },
-        "universalify": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-          "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
-          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -49,22 +49,25 @@
     "release": "npm run build && changeset publish"
   },
   "dependencies": {
-    "emitten": "^0.2.0"
+    "emitten": "^0.3.0"
   },
   "devDependencies": {
     "@changesets/changelog-github": "^0.4.8",
     "@changesets/cli": "^2.26.0",
     "@types/node": "^18.11.18",
     "@typescript-eslint/eslint-plugin": "^5.49.0",
-    "eslint": "^8.32.0",
+    "eslint": "^8.33.0",
     "eslint-config-prettier": "^8.6.0",
     "eslint-config-standard-with-typescript": "^33.0.0",
     "eslint-plugin-import": "^2.27.5",
     "eslint-plugin-n": "^15.6.1",
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-promise": "^6.1.1",
-    "typescript": "^4.9.4",
+    "typescript": "^4.9.5",
     "vite": "^4.0.4",
     "vite-plugin-dts": "^1.7.1"
+  },
+  "peerDependencies": {
+    "emitten": "^0.3.0"
   }
 }

--- a/src/Earwurm.ts
+++ b/src/Earwurm.ts
@@ -1,5 +1,4 @@
-import {EmittenProtected} from 'emitten';
-import type {EmittenListener} from 'emitten';
+import {EmittenCommon} from 'emitten';
 
 import {getErrorMessage, unlockAudioContext} from './helpers';
 import {clamp, msToSec, secToMs} from './utilities';
@@ -16,7 +15,7 @@ import type {
 
 import {Stack} from './Stack';
 
-export class Earwurm extends EmittenProtected<ManagerEventMap> {
+export class Earwurm extends EmittenCommon<ManagerEventMap> {
   static readonly maxStackSize = tokens.maxStackSize;
   static readonly suspendAfterMs = tokens.suspendAfterMs;
 
@@ -291,36 +290,4 @@ export class Earwurm extends EmittenProtected<ManagerEventMap> {
       this.#autoSuspend();
     }
   };
-
-  ///
-  /// Emitten method exposure
-
-  public off<TKey extends keyof ManagerEventMap>(
-    eventName: TKey,
-    listener: EmittenListener<ManagerEventMap[TKey]>,
-  ) {
-    super.off(eventName, listener);
-  }
-
-  public on<TKey extends keyof ManagerEventMap>(
-    eventName: TKey,
-    listener: EmittenListener<ManagerEventMap[TKey]>,
-  ) {
-    super.on(eventName, listener);
-  }
-
-  public once<TKey extends keyof ManagerEventMap>(
-    eventName: TKey,
-    listener: EmittenListener<ManagerEventMap[TKey]>,
-  ) {
-    super.once(eventName, listener);
-  }
-
-  public disposable<TKey extends keyof ManagerEventMap>(
-    eventName: TKey,
-    listener: EmittenListener<ManagerEventMap[TKey]>,
-  ) {
-    const result = super.disposable(eventName, listener);
-    return result;
-  }
 }

--- a/src/Sound.ts
+++ b/src/Sound.ts
@@ -1,10 +1,9 @@
-import {EmittenProtected} from 'emitten';
-import type {EmittenListener} from 'emitten';
+import {EmittenCommon} from 'emitten';
 
 import {clamp, msToSec} from './utilities';
 import type {SoundId, SoundState, SoundEventMap, SoundConfig} from './types';
 
-export class Sound extends EmittenProtected<SoundEventMap> {
+export class Sound extends EmittenCommon<SoundEventMap> {
   // "Readonly accessor" properties
   private _volume = 1;
   private _mute = false;
@@ -134,36 +133,4 @@ export class Sound extends EmittenProtected<SoundEventMap> {
   #handleEnded = () => {
     this.emit('ended', {id: this.id, source: this.#source});
   };
-
-  ///
-  /// Emitten method exposure
-
-  public off<TKey extends keyof SoundEventMap>(
-    eventName: TKey,
-    listener: EmittenListener<SoundEventMap[TKey]>,
-  ) {
-    super.off(eventName, listener);
-  }
-
-  public on<TKey extends keyof SoundEventMap>(
-    eventName: TKey,
-    listener: EmittenListener<SoundEventMap[TKey]>,
-  ) {
-    super.on(eventName, listener);
-  }
-
-  public once<TKey extends keyof SoundEventMap>(
-    eventName: TKey,
-    listener: EmittenListener<SoundEventMap[TKey]>,
-  ) {
-    super.once(eventName, listener);
-  }
-
-  public disposable<TKey extends keyof SoundEventMap>(
-    eventName: TKey,
-    listener: EmittenListener<SoundEventMap[TKey]>,
-  ) {
-    const result = super.disposable(eventName, listener);
-    return result;
-  }
 }

--- a/src/Stack.ts
+++ b/src/Stack.ts
@@ -1,5 +1,4 @@
-import {EmittenProtected} from 'emitten';
-import type {EmittenListener} from 'emitten';
+import {EmittenCommon} from 'emitten';
 
 import {getErrorMessage, fetchAudioBuffer, scratchBuffer} from './helpers';
 import {clamp, msToSec, secToMs} from './utilities';
@@ -8,6 +7,7 @@ import {tokens} from './tokens';
 import type {
   StackId,
   StackState,
+  StackError,
   StackEventMap,
   StackConfig,
   SoundId,
@@ -16,14 +16,14 @@ import type {
 
 import {Sound} from './Sound';
 
-export class Stack extends EmittenProtected<StackEventMap> {
+export class Stack extends EmittenCommon<StackEventMap> {
   static readonly maxStackSize = tokens.maxStackSize;
 
   static #loadError = (
     id: StackId,
     path: string,
     error: string,
-  ): StackEventMap['error'] => ({
+  ): StackError => ({
     id,
     message: [`Failed to load: ${path}`, getErrorMessage(error)],
   });
@@ -209,41 +209,9 @@ export class Stack extends EmittenProtected<StackEventMap> {
     this.#setState(this.playing ? 'playing' : 'idle');
   };
 
-  #handleSoundEnded = (event?: SoundEndedEvent) => {
+  #handleSoundEnded = (event: SoundEndedEvent) => {
     // TODO: `event` should never be `undefined`.
     // This needs to be fixed within `Emitten`.
     this.#setQueue(this.#queue.filter(({id}) => id !== event?.id));
   };
-
-  ///
-  /// Emitten method exposure
-
-  public off<TKey extends keyof StackEventMap>(
-    eventName: TKey,
-    listener: EmittenListener<StackEventMap[TKey]>,
-  ) {
-    super.off(eventName, listener);
-  }
-
-  public on<TKey extends keyof StackEventMap>(
-    eventName: TKey,
-    listener: EmittenListener<StackEventMap[TKey]>,
-  ) {
-    super.on(eventName, listener);
-  }
-
-  public once<TKey extends keyof StackEventMap>(
-    eventName: TKey,
-    listener: EmittenListener<StackEventMap[TKey]>,
-  ) {
-    super.once(eventName, listener);
-  }
-
-  public disposable<TKey extends keyof StackEventMap>(
-    eventName: TKey,
-    listener: EmittenListener<StackEventMap[TKey]>,
-  ) {
-    const result = super.disposable(eventName, listener);
-    return result;
-  }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,10 +7,11 @@ export type CombinedErrorMessage = [string, string];
 
 export type ManagerState = AudioContextState | 'suspending' | 'interrupted';
 
-export interface ManagerEventMap {
-  statechange: ManagerState;
-  error: CombinedErrorMessage;
-}
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+export type ManagerEventMap = {
+  statechange(state: ManagerState): void;
+  error(error: CombinedErrorMessage): void;
+};
 
 export interface ManagerConfig {
   volume?: number;
@@ -36,10 +37,11 @@ export interface StackError {
   message: CombinedErrorMessage;
 }
 
-export interface StackEventMap {
-  statechange: StackState;
-  error: StackError;
-}
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+export type StackEventMap = {
+  statechange(state: StackState): void;
+  error(error: StackError): void;
+};
 
 export interface StackConfig {
   volume?: number;
@@ -60,11 +62,12 @@ export interface SoundEndedEvent {
   source: AudioBufferSourceNode;
 }
 
-export interface SoundEventMap {
-  statechange: SoundState;
-  ended: SoundEndedEvent;
-  // loop: boolean;
-}
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+export type SoundEventMap = {
+  statechange(state: SoundState): void;
+  ended(event: SoundEndedEvent): void;
+  // loop(ended: boolean): void;
+};
 
 export interface SoundConfig {
   volume?: number;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,12 +1,19 @@
 import {defineConfig} from 'vite';
 import dts from 'vite-plugin-dts';
 
+import pkg from './package.json';
+
 export default defineConfig({
   build: {
     lib: {
       entry: 'src/index.ts',
       name: 'earwurm',
       fileName: (format) => `earwurm.${format}.js`,
+    },
+    rollupOptions: {
+      // We might need to define global variables
+      // to use in the UMD build.
+      external: Object.keys(pkg.peerDependencies || {}),
     },
     minify: false,
   },


### PR DESCRIPTION
**This PR:**

- Bumps `emitten` to `v0.3.0`.
- Includes `emitten` as a `peerDependency`
- Updates the `vite` config to keep `emitten` out of the build.
- Revises `.eslintrc` for a single TypeScript rule.