### PR TITLE
🧰 [Dependency] Explicitly declare `prettier` as a `devDependency`

### DIFF
--- a/.changeset/purple-zebras-glow.md
+++ b/.changeset/purple-zebras-glow.md
@@ -1,0 +1,5 @@
+---
+'earwurm': patch
+---
+
+Include prettier in devDependencies

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "earwurm",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "earwurm",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "ISC",
       "dependencies": {
         "emitten": "^0.6.0"
@@ -26,6 +26,7 @@
         "eslint-plugin-prettier": "^5.0.1",
         "eslint-plugin-promise": "^6.1.1",
         "happy-dom": "^12.10.3",
+        "prettier": "^3.1.0",
         "typescript": "^5.3.2",
         "vite": "^5.0.2",
         "vite-plugin-dts": "^3.6.3",
@@ -5637,7 +5638,6 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.1.0.tgz",
       "integrity": "sha512-TQLvXjq5IAibjh8EpBIkNKxO749UEWABoiIZehEPiY4GNpVdhaFKqSTu+QrlU6D2dPAfubRmtJTi4K4YkQ5eXw==",
       "dev": true,
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "eslint-plugin-prettier": "^5.0.1",
     "eslint-plugin-promise": "^6.1.1",
     "happy-dom": "^12.10.3",
+    "prettier": "^3.1.0",
     "typescript": "^5.3.2",
     "vite": "^5.0.2",
     "vite-plugin-dts": "^3.6.3",


### PR DESCRIPTION
It appears I missed a spot.