### PR TITLE
🛠️ [Package] Add types to exports object to fix some build configs

### DIFF
--- a/.changeset/flat-phones-think.md
+++ b/.changeset/flat-phones-think.md
@@ -1,0 +1,5 @@
+---
+'earwurm': patch
+---
+
+Fix failure to resolve types in some projects.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,20 +1,20 @@
 {
   "name": "earwurm",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "earwurm",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "ISC",
       "dependencies": {
-        "emitten": "^0.6.0"
+        "emitten": "^0.6.1"
       },
       "devDependencies": {
         "@changesets/changelog-github": "^0.4.8",
         "@changesets/cli": "^2.26.2",
-        "@types/node": "^20.9.4",
+        "@types/node": "^20.10.0",
         "@typescript-eslint/eslint-plugin": "^6.12.0",
         "@vitest/coverage-v8": "^0.34.6",
         "@vitest/ui": "^0.34.6",
@@ -37,7 +37,7 @@
         "npm": ">=10.2.3"
       },
       "peerDependencies": {
-        "emitten": "^0.6.0"
+        "emitten": "^0.6.1"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -1163,9 +1163,9 @@
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.5.1.tgz",
-      "integrity": "sha512-YaN43wTyEBaMqLDYeze+gQ4ZrW5RbTEGtT5o1GVDkhpdNcsLTnLRcLccvwy3E9wiDKWg9RIhuoy3JQKDRBfaZA==",
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.5.2.tgz",
+      "integrity": "sha512-ee7BudTwwrglFYSc3UnqInDDjCLWHKrFmGNi4aK7jlEyg4CyPa1DCMrZfsN1O13YT76UFEqXz2CoN7BCGpUlJw==",
       "cpu": [
         "arm"
       ],
@@ -1176,9 +1176,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.5.1.tgz",
-      "integrity": "sha512-n1bX+LCGlQVuPlCofO0zOKe1b2XkFozAVRoczT+yxWZPGnkEAKTTYVOGZz8N4sKuBnKMxDbfhUsB1uwYdup/sw==",
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.5.2.tgz",
+      "integrity": "sha512-xOuhj9HHtn8128ir8veoQsBbAUBasDbHIBniYTEx02pAmu9EXL+ZjJqngnNEy6ZgZ4h1JwL33GMNu3yJL5Mzow==",
       "cpu": [
         "arm64"
       ],
@@ -1189,9 +1189,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.5.1.tgz",
-      "integrity": "sha512-QqJBumdvfBqBBmyGHlKxje+iowZwrHna7pokj/Go3dV1PJekSKfmjKrjKQ/e6ESTGhkfPNLq3VXdYLAc+UtAQw==",
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.5.2.tgz",
+      "integrity": "sha512-NTGJWoL8bKyqyWFn9/RzSv4hQ4wTbaAv0lHHRwf4OnpiiP4P8W0jiXbm8Nc5BCXKmWAwuvJY82mcIU2TayC20g==",
       "cpu": [
         "arm64"
       ],
@@ -1202,9 +1202,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.5.1.tgz",
-      "integrity": "sha512-RrkDNkR/P5AEQSPkxQPmd2ri8WTjSl0RYmuFOiEABkEY/FSg0a4riihWQGKDJ4LnV9gigWZlTMx2DtFGzUrYQw==",
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.5.2.tgz",
+      "integrity": "sha512-hlKqj7bpPvU15sZo4za14u185lpMzdwWLMc9raMqPK4wywt0wR23y1CaVQ4oAFXat3b5/gmRntyfpwWTKl+vvA==",
       "cpu": [
         "x64"
       ],
@@ -1215,9 +1215,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.5.1.tgz",
-      "integrity": "sha512-ZFPxvUZmE+fkB/8D9y/SWl/XaDzNSaxd1TJUSE27XAKlRpQ2VNce/86bGd9mEUgL3qrvjJ9XTGwoX0BrJkYK/A==",
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.5.2.tgz",
+      "integrity": "sha512-7ZIZx8c3u+pfI0ohQsft/GywrXez0uR6dUP0JhBuCK3sFO5TfdLn/YApnVkvPxuTv3+YKPIZend9Mt7Cz6sS3Q==",
       "cpu": [
         "arm"
       ],
@@ -1228,9 +1228,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.5.1.tgz",
-      "integrity": "sha512-FEuAjzVIld5WVhu+M2OewLmjmbXWd3q7Zcx+Rwy4QObQCqfblriDMMS7p7+pwgjZoo9BLkP3wa9uglQXzsB9ww==",
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.5.2.tgz",
+      "integrity": "sha512-7Pk/5mO11JW/cH+a8lL/i0ZxmRGrbpYqN0VwO2DHhU+SJWWOH2zE1RAcPaj8KqiwC8DCDIJOSxjV9+9lLb6aeA==",
       "cpu": [
         "arm64"
       ],
@@ -1241,9 +1241,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.5.1.tgz",
-      "integrity": "sha512-f5Gs8WQixqGRtI0Iq/cMqvFYmgFzMinuJO24KRfnv7Ohi/HQclwrBCYkzQu1XfLEEt3DZyvveq9HWo4bLJf1Lw==",
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.5.2.tgz",
+      "integrity": "sha512-KrRnuG5phJx756e62wxvWH2e+TK84MP2IVuPwfge+GBvWqIUfVzFRn09TKruuQBXzZp52Vyma7FjMDkwlA9xpg==",
       "cpu": [
         "arm64"
       ],
@@ -1254,9 +1254,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.5.1.tgz",
-      "integrity": "sha512-CWPkPGrFfN2vj3mw+S7A/4ZaU3rTV7AkXUr08W9lNP+UzOvKLVf34tWCqrKrfwQ0NTk5GFqUr2XGpeR2p6R4gw==",
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.5.2.tgz",
+      "integrity": "sha512-My+53GasPa2D2tU5dXiyHYwrELAUouSfkNlZ3bUKpI7btaztO5vpALEs3mvFjM7aKTvEbc7GQckuXeXIDKQ0fg==",
       "cpu": [
         "x64"
       ],
@@ -1267,9 +1267,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.5.1.tgz",
-      "integrity": "sha512-ZRETMFA0uVukUC9u31Ed1nx++29073goCxZtmZARwk5aF/ltuENaeTtRVsSQzFlzdd4J6L3qUm+EW8cbGt0CKQ==",
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.5.2.tgz",
+      "integrity": "sha512-/f0Q6Sc+Vw54Ws6N8fxaEe4R7at3b8pFyv+O/F2VaQ4hODUJcRUcCBJh6zuqtgQQt7w845VTkGLFgWZkP3tUoQ==",
       "cpu": [
         "x64"
       ],
@@ -1280,9 +1280,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.5.1.tgz",
-      "integrity": "sha512-ihqfNJNb2XtoZMSCPeoo0cYMgU04ksyFIoOw5S0JUVbOhafLot+KD82vpKXOurE2+9o/awrqIxku9MRR9hozHQ==",
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.5.2.tgz",
+      "integrity": "sha512-NCKuuZWLht6zj7s6EIFef4BxCRX1GMr83S2W4HPCA0RnJ4iHE4FS1695q6Ewoa6A9nFjJe1//yUu0kgBU07Edw==",
       "cpu": [
         "arm64"
       ],
@@ -1293,9 +1293,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.5.1.tgz",
-      "integrity": "sha512-zK9MRpC8946lQ9ypFn4gLpdwr5a01aQ/odiIJeL9EbgZDMgbZjjT/XzTqJvDfTmnE1kHdbG20sAeNlpc91/wbg==",
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.5.2.tgz",
+      "integrity": "sha512-J5zL3riR4AOyU/J3M/i4k/zZ8eP1yT+nTmAKztCXJtnI36jYH0eepvob22mAQ/kLwfsK2TB6dbyVY1F8c/0H5A==",
       "cpu": [
         "ia32"
       ],
@@ -1306,9 +1306,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.5.1.tgz",
-      "integrity": "sha512-5I3Nz4Sb9TYOtkRwlH0ow+BhMH2vnh38tZ4J4mggE48M/YyJyp/0sPSxhw1UeS1+oBgQ8q7maFtSeKpeRJu41Q==",
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.5.2.tgz",
+      "integrity": "sha512-pL0RXRHuuGLhvs7ayX/SAHph1hrDPXOM5anyYUQXWJEENxw3nfHkzv8FfVlEVcLyKPAEgDRkd6RKZq2SMqS/yg==",
       "cpu": [
         "x64"
       ],
@@ -1430,9 +1430,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.9.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.9.4.tgz",
-      "integrity": "sha512-wmyg8HUhcn6ACjsn8oKYjkN/zUzQeNtMy44weTJSM6p4MMzEOuKbA3OjJ267uPCOW7Xex9dyrNTful8XTQYoDA==",
+      "version": "20.10.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.10.0.tgz",
+      "integrity": "sha512-D0WfRmU9TQ8I9PFx9Yc+EBHw+vSpIub4IDvQivcp26PtPrdMGAq5SDcpXEo/epqa/DXotVpekHiLNTg3iaKXBQ==",
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
@@ -2689,9 +2689,9 @@
       }
     },
     "node_modules/emitten": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/emitten/-/emitten-0.6.0.tgz",
-      "integrity": "sha512-IQa/zrGe6X6Qx3+NGdnOkKCNzQWcW4E3jVgRLKDoPtu0fiKe1HrxnCAKw4v6ZbS+8qNouxwOln7Evhm6ezABdA==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/emitten/-/emitten-0.6.1.tgz",
+      "integrity": "sha512-8bH3RqL+rFqVYaLd6j5tGGCitJfW0B8/Ofi/IQ4hvwMAZtKbHK4V7VmSPQx3bMC21yuyNR9bKK6wRGgBMWp09A==",
       "engines": {
         "node": ">=20.10.0",
         "npm": ">=10.2.3"
@@ -5913,9 +5913,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.5.1.tgz",
-      "integrity": "sha512-0EQribZoPKpb5z1NW/QYm3XSR//Xr8BeEXU49Lc/mQmpmVVG5jPUVrpc2iptup/0WMrY9mzas0fxH+TjYvG2CA==",
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.5.2.tgz",
+      "integrity": "sha512-CRK1uoROBfkcqrZKyaFcqCcZWNsvJ6yVYZkqTlRocZhO2s5yER6Z3f/QaYtO8RGyloPnmhwgzuPQpNGeK210xQ==",
       "dev": true,
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -5925,18 +5925,18 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.5.1",
-        "@rollup/rollup-android-arm64": "4.5.1",
-        "@rollup/rollup-darwin-arm64": "4.5.1",
-        "@rollup/rollup-darwin-x64": "4.5.1",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.5.1",
-        "@rollup/rollup-linux-arm64-gnu": "4.5.1",
-        "@rollup/rollup-linux-arm64-musl": "4.5.1",
-        "@rollup/rollup-linux-x64-gnu": "4.5.1",
-        "@rollup/rollup-linux-x64-musl": "4.5.1",
-        "@rollup/rollup-win32-arm64-msvc": "4.5.1",
-        "@rollup/rollup-win32-ia32-msvc": "4.5.1",
-        "@rollup/rollup-win32-x64-msvc": "4.5.1",
+        "@rollup/rollup-android-arm-eabi": "4.5.2",
+        "@rollup/rollup-android-arm64": "4.5.2",
+        "@rollup/rollup-darwin-arm64": "4.5.2",
+        "@rollup/rollup-darwin-x64": "4.5.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.5.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.5.2",
+        "@rollup/rollup-linux-arm64-musl": "4.5.2",
+        "@rollup/rollup-linux-x64-gnu": "4.5.2",
+        "@rollup/rollup-linux-x64-musl": "4.5.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.5.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.5.2",
+        "@rollup/rollup-win32-x64-msvc": "4.5.2",
         "fsevents": "~2.3.2"
       }
     },

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
   "exports": {
     ".": {
       "import": "./dist/earwurm.es.js",
-      "require": "./dist/earwurm.umd.js"
+      "require": "./dist/earwurm.umd.js",
+      "types": "./dist/index.d.ts"
     }
   },
   "engines": {
@@ -55,12 +56,12 @@
     "release": "npm run build && changeset publish"
   },
   "dependencies": {
-    "emitten": "^0.6.0"
+    "emitten": "^0.6.1"
   },
   "devDependencies": {
     "@changesets/changelog-github": "^0.4.8",
     "@changesets/cli": "^2.26.2",
-    "@types/node": "^20.9.4",
+    "@types/node": "^20.10.0",
     "@typescript-eslint/eslint-plugin": "^6.12.0",
     "@vitest/coverage-v8": "^0.34.6",
     "@vitest/ui": "^0.34.6",
@@ -79,6 +80,6 @@
     "vitest": "^0.34.6"
   },
   "peerDependencies": {
-    "emitten": "^0.6.0"
+    "emitten": "^0.6.1"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "target": "esnext",
     "module": "esnext",
     "lib": ["esnext", "dom"],
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "strict": true,
     "allowJs": false,
     "allowSyntheticDefaultImports": true,


### PR DESCRIPTION
Just like with `emitten`, I am repeating the `types` entry within `exports` to try and solve the failure to resolve `types` in consumer projects.