### PR TITLE
🤡 [Dummy] Shell representations of core classes

### DIFF
--- a/src/dummy/DummyEarwurm.ts
+++ b/src/dummy/DummyEarwurm.ts
@@ -1,0 +1,69 @@
+import {tokens} from '../tokens';
+import type {LibraryEntry, LibraryKeys} from '../types';
+
+// TODO: Ideally we can do something like `implements Earwurm`,
+// but changing all internal logic to be "dumb".
+export class DummyEarwurm {
+  static readonly maxStackSize = tokens.maxStackSize;
+  static readonly suspendAfterMs = tokens.suspendAfterMs;
+
+  private _volume = 1;
+  private _mute = false;
+
+  readonly unlocked = false;
+  readonly state = 'closed';
+  readonly playing = false;
+
+  constructor() {
+    this._volume = 1;
+    this._mute = false;
+  }
+
+  get volume() {
+    return this._volume;
+  }
+
+  set volume(value: number) {
+    this._volume = value;
+  }
+
+  get mute() {
+    return this._mute;
+  }
+
+  set mute(value: boolean) {
+    this._mute = value;
+  }
+
+  get keys() {
+    return [];
+  }
+
+  get(_id: LibraryEntry['id']) {
+    return undefined;
+  }
+
+  has(_id: LibraryEntry['id']) {
+    return false;
+  }
+
+  unlock() {
+    return this;
+  }
+
+  add(..._entries: LibraryEntry[]): LibraryKeys {
+    return [];
+  }
+
+  remove(..._ids: LibraryKeys): LibraryKeys {
+    return [];
+  }
+
+  stop() {
+    return this;
+  }
+
+  teardown() {
+    return this;
+  }
+}

--- a/src/dummy/index.ts
+++ b/src/dummy/index.ts
@@ -1,0 +1,1 @@
+export {DummyEarwurm} from './DummyEarwurm';

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,8 @@ export {Earwurm} from './Earwurm';
 export {Stack} from './Stack';
 export {Sound} from './Sound';
 
+// export * from './dummy';
+
 export type {
   ManagerState,
   ManagerEventMap,


### PR DESCRIPTION
This PR is an experiment with trying to offer some super barebones implementation for each class: `Earwurm`, `Stack`, and `Sound`.

**The expectation here is that I'd be able to just do something like:**

`export class DummyEarwurm implements Earwurm {}`

Hit `save` and `VsCode` would auto-generate the minimal implementation... that did not work however.

**The goal is to avoid help avoid optional chaining:**

`const someStack = manager.get('thing') ?? DummyStackSingleton`

Not sure if this experiment is really worth it.
