### PR TITLE
⚗️ [Earwurm] Remove `bundleDependencies` and just use `devDependencies`

### DIFF
--- a/.changeset/eighty-tools-dream.md
+++ b/.changeset/eighty-tools-dream.md
@@ -1,0 +1,5 @@
+---
+"earwurm": patch
+---
+
+Remove bundleDependencies and just use devDependencies.

--- a/pkg/earwurm/package.json
+++ b/pkg/earwurm/package.json
@@ -47,19 +47,14 @@
     "build": "pnpm clean && pnpm build:only",
     "start": "pnpm build:only --watch"
   },
-  "bundleDependencies": [
-    "@earwurm/helpers",
-    "@earwurm/types",
-    "@earwurm/utilities"
-  ],
   "dependencies": {
-    "@earwurm/helpers": "workspace:*",
-    "@earwurm/types": "workspace:*",
-    "@earwurm/utilities": "workspace:*",
     "emitten": "^0.6.3"
   },
   "devDependencies": {
+    "@earwurm/helpers": "workspace:*",
     "@earwurm/mocks": "workspace:*",
+    "@earwurm/types": "workspace:*",
+    "@earwurm/utilities": "workspace:*",
     "vite": "^5.0.12",
     "vite-plugin-dts": "^3.7.1"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -111,22 +111,22 @@ importers:
 
   pkg/earwurm:
     dependencies:
+      emitten:
+        specifier: ^0.6.3
+        version: 0.6.3
+    devDependencies:
       '@earwurm/helpers':
         specifier: workspace:*
         version: link:../helpers
+      '@earwurm/mocks':
+        specifier: workspace:*
+        version: link:../mocks
       '@earwurm/types':
         specifier: workspace:*
         version: link:../types
       '@earwurm/utilities':
         specifier: workspace:*
         version: link:../utilities
-      emitten:
-        specifier: ^0.6.3
-        version: 0.6.3
-    devDependencies:
-      '@earwurm/mocks':
-        specifier: workspace:*
-        version: link:../mocks
       vite:
         specifier: ^5.0.12
         version: 5.0.12(@types/node@20.11.5)(lightningcss@1.23.0)


### PR DESCRIPTION
Again, trying to fix the `npm install` issue.