### PR TITLE
🐞 [Website] Add some debugging UI

### DIFF
--- a/.changeset/blue-jank-crime.md
+++ b/.changeset/blue-jank-crime.md
@@ -1,0 +1,5 @@
+---
+"earwurm": minor
+---
+
+Remove timed auto-suspend in favour of exposing `.suspend() / .resume()` methods on `Earuwrm`.

--- a/.changeset/thick-oranges-exercise.md
+++ b/.changeset/thick-oranges-exercise.md
@@ -1,0 +1,5 @@
+---
+"earwurm": minor
+---
+
+New `play` event available on `Earwurm` instance.

--- a/app/website/package.json
+++ b/app/website/package.json
@@ -13,7 +13,7 @@
   "type": "module",
   "engines": {
     "node": ">=20.10.0",
-    "pnpm": ">=8.14.0"
+    "pnpm": ">=8.15.0"
   },
   "scripts": {
     "clean": "rm -rf dist && rm -rf *.tsbuildinfo",
@@ -32,7 +32,7 @@
   },
   "devDependencies": {
     "@earwurm/types": "workspace:*",
-    "@rushstack/eslint-patch": "^1.7.0",
+    "@rushstack/eslint-patch": "^1.7.2",
     "@tsconfig/node20": "^20.1.2",
     "@vitejs/plugin-vue": "^5.0.3",
     "@vue/eslint-config-prettier": "^9.0.0",

--- a/app/website/src/components/StackLabel.vue
+++ b/app/website/src/components/StackLabel.vue
@@ -4,6 +4,7 @@ import {classNames} from '@/helpers';
 export interface StackLabelProps {
   label: string;
   populated?: boolean;
+  truncate?: boolean;
 }
 
 defineProps<StackLabelProps>();
@@ -11,7 +12,7 @@ defineProps<StackLabelProps>();
 
 <template>
   <div :class="classNames('StackLabel', {populated})">
-    <p class="Text">{{ label }}</p>
+    <p :class="classNames('Text', {truncate})">{{ label }}</p>
   </div>
 </template>
 
@@ -21,6 +22,7 @@ defineProps<StackLabelProps>();
   place-items: center;
   place-content: center;
   padding: 0.8rem;
+  flex: 0 0 auto;
   min-width: var(--row-height);
   height: var(--row-height);
   color: var(--color-primary);
@@ -37,8 +39,11 @@ defineProps<StackLabelProps>();
 }
 
 .Text {
+  font-size: 1.4rem;
+}
+
+.truncate {
   @apply truncate;
   @apply flex-fix-width;
-  font-size: 1.4rem;
 }
 </style>

--- a/app/website/src/hooks/useSupported.ts
+++ b/app/website/src/hooks/useSupported.ts
@@ -2,7 +2,7 @@ import {computed} from 'vue';
 import {useMounted} from './useMounted';
 
 // Adapted from Vue Use: https://vueuse.org/
-export function useSupported(callback: () => unknown) {
+export function useSupported(callback: () => boolean) {
   const isMounted = useMounted();
 
   return computed(() => {

--- a/app/website/src/sections/ManagerDebug.vue
+++ b/app/website/src/sections/ManagerDebug.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import {computed} from 'vue';
+import {computed, type ComponentPublicInstance} from 'vue';
 
 import {useDebugManager, useEarwurmStore} from '@/store';
 import {IconAction, StackLabel} from '@/components';
@@ -23,6 +23,12 @@ function togglePlayback() {
     manager.resume();
   }
 }
+
+function scrollEnd(element: Element | ComponentPublicInstance | null) {
+  if (element instanceof Element) {
+    element.scroll({left: 12345, behavior: 'smooth'});
+  }
+}
 </script>
 
 <template>
@@ -30,7 +36,10 @@ function togglePlayback() {
     <div class="collapsed-border-row">
       <StackLabel label="Stacks" populated />
 
-      <ul class="DebugList collapsed-border-row--reverse pattern-halftone">
+      <ul
+        :ref="(el) => scrollEnd(el)"
+        class="DebugList collapsed-border-row pattern-halftone"
+      >
         <li v-for="stack in activeStacks" :key="stack" class="DebugItem">
           <StackLabel :label="stack" />
         </li>
@@ -40,7 +49,10 @@ function togglePlayback() {
     <div class="collapsed-border-row">
       <StackLabel label="State" populated />
 
-      <ul class="DebugList collapsed-border-row--reverse pattern-halftone">
+      <ul
+        :ref="(el) => scrollEnd(el)"
+        class="DebugList collapsed-border-row pattern-halftone"
+      >
         <li
           v-for="(state, index) in stateHistory"
           :key="`${state}-${index}`"
@@ -54,7 +66,10 @@ function togglePlayback() {
     <div class="collapsed-border-row">
       <StackLabel label="Errors" populated />
 
-      <ul class="DebugList collapsed-border-row--reverse pattern-halftone">
+      <ul
+        :ref="(el) => scrollEnd(el)"
+        class="DebugList collapsed-border-row pattern-halftone"
+      >
         <li
           v-for="(error, index) in errorHistory"
           :key="[...error, index].join(' | ')"
@@ -69,7 +84,8 @@ function togglePlayback() {
       <StackLabel label="Unlocked" populated />
 
       <ul
-        class="DebugList collapsed-border-row--reverse pattern-halftone--reverse pattern-halftone"
+        :ref="(el) => scrollEnd(el)"
+        class="DebugList collapsed-border-row pattern-halftone"
       >
         <li
           v-for="(status, index) in unlockHistory"
@@ -84,7 +100,10 @@ function togglePlayback() {
     <div class="collapsed-border-row">
       <StackLabel label="Playing" populated />
 
-      <ul class="DebugList collapsed-border-row--reverse pattern-halftone">
+      <ul
+        :ref="(el) => scrollEnd(el)"
+        class="DebugList collapsed-border-row pattern-halftone"
+      >
         <li
           v-for="(status, index) in playHistory"
           :key="`Playing-${status}-${index}`"
@@ -139,7 +158,6 @@ function togglePlayback() {
 
 .DebugList {
   counter-reset: debug-counter;
-  flex-direction: row-reverse;
   flex: 1 1 auto;
   box-shadow: inset 0 0 0 var(--app-border-width) var(--color-primary);
   overflow-x: scroll;
@@ -148,6 +166,10 @@ function togglePlayback() {
 .DebugItem {
   counter-increment: debug-counter;
   position: relative;
+
+  &:first-child {
+    margin-left: auto;
+  }
 
   &::before {
     content: counter(debug-counter);
@@ -165,8 +187,25 @@ function togglePlayback() {
     box-shadow: inset 0 0 0 var(--app-border-width) var(--color-primary);
   }
 
+  &::after {
+    @apply interaction-disable;
+    content: '';
+    display: block;
+    position: absolute;
+    inset: 0;
+    opacity: 0;
+    background-color: var(--color-primary);
+    transition: opacity var(--duration-slow) var(--easing-cubic);
+  }
+
   & > div {
     padding-left: 2rem;
+  }
+}
+
+@starting-style {
+  .DebugItem::after {
+    opacity: 1;
   }
 }
 </style>

--- a/app/website/src/sections/ManagerDebug.vue
+++ b/app/website/src/sections/ManagerDebug.vue
@@ -1,0 +1,137 @@
+<script setup lang="ts">
+import {useDebugManager} from '@/store';
+import {StackLabel} from '@/components';
+
+const {activeStacks, stateHistory, errorHistory, unlockHistory, playHistory} =
+  useDebugManager();
+</script>
+
+<template>
+  <section class="ManagerDebug collapsed-border-grid">
+    <div class="collapsed-border-row">
+      <StackLabel label="Stacks" populated />
+
+      <ul class="DebugList collapsed-border-row--reverse pattern-halftone">
+        <li v-for="stack in activeStacks" :key="stack" class="DebugItem">
+          <StackLabel :label="stack" />
+        </li>
+      </ul>
+    </div>
+
+    <div class="collapsed-border-row">
+      <StackLabel label="State" populated />
+
+      <ul class="DebugList collapsed-border-row--reverse pattern-halftone">
+        <li
+          v-for="(state, index) in stateHistory"
+          :key="`${state}-${index}`"
+          class="DebugItem"
+        >
+          <StackLabel :label="state" />
+        </li>
+      </ul>
+    </div>
+
+    <div class="collapsed-border-row">
+      <StackLabel label="Errors" populated />
+
+      <ul class="DebugList collapsed-border-row--reverse pattern-halftone">
+        <li
+          v-for="(error, index) in errorHistory"
+          :key="[...error, index].join(' | ')"
+          class="DebugItem"
+        >
+          <StackLabel :label="error.join(' | ')" />
+        </li>
+      </ul>
+    </div>
+
+    <div class="collapsed-border-row">
+      <StackLabel label="Unlocked" populated />
+
+      <ul
+        class="DebugList collapsed-border-row--reverse pattern-halftone--reverse pattern-halftone"
+      >
+        <li
+          v-for="(status, index) in unlockHistory"
+          :key="`Unlocked-${status}-${index}`"
+          class="DebugItem"
+        >
+          <StackLabel :label="status.toString()" />
+        </li>
+      </ul>
+    </div>
+
+    <div class="collapsed-border-row">
+      <StackLabel label="Playing" populated />
+
+      <ul class="DebugList collapsed-border-row--reverse pattern-halftone">
+        <li
+          v-for="(status, index) in playHistory"
+          :key="`Playing-${status}-${index}`"
+          class="DebugItem"
+        >
+          <StackLabel :label="status.toString()" />
+        </li>
+      </ul>
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.ManagerDebug {
+  @apply flex-fix-width;
+  position: relative;
+
+  /*
+   * Overlaid border required so that our DebugList
+   * can scroll behind the border lines.
+  */
+  &::before {
+    @apply interaction-disable;
+    @apply position-cover;
+    z-index: 2;
+    content: '';
+    display: block;
+    box-shadow: inset 0 0 0 var(--app-border-width) var(--color-primary);
+  }
+
+  > .collapsed-border-row {
+    position: relative;
+    z-index: 1;
+  }
+}
+
+.DebugList {
+  counter-reset: debug-counter;
+  flex-direction: row-reverse;
+  flex: 1 1 auto;
+  box-shadow: inset 0 0 0 var(--app-border-width) var(--color-primary);
+  overflow-x: scroll;
+}
+
+.DebugItem {
+  counter-increment: debug-counter;
+  position: relative;
+
+  &::before {
+    content: counter(debug-counter);
+    position: absolute;
+    top: 50%;
+    margin-top: calc(1.6em / 2 * -1);
+    left: calc(var(--app-border-width) * 2);
+    display: grid;
+    place-items: center;
+    place-content: center;
+    width: 1.6em;
+    height: 1.6em;
+    font-size: 1rem;
+    color: var(--color-primary);
+    box-shadow: inset 0 0 0 var(--app-border-width) var(--color-primary);
+  }
+
+  & > div {
+    padding-left: 2rem;
+  }
+}
+</style>

--- a/app/website/src/sections/ManagerDebug.vue
+++ b/app/website/src/sections/ManagerDebug.vue
@@ -1,9 +1,28 @@
 <script setup lang="ts">
-import {useDebugManager} from '@/store';
-import {StackLabel} from '@/components';
+import {computed} from 'vue';
 
-const {activeStacks, stateHistory, errorHistory, unlockHistory, playHistory} =
-  useDebugManager();
+import {useDebugManager, useEarwurmStore} from '@/store';
+import {IconAction, StackLabel} from '@/components';
+
+const {manager} = useEarwurmStore();
+const {
+  activeStacks,
+  currentState,
+  stateHistory,
+  errorHistory,
+  unlockHistory,
+  playHistory,
+} = useDebugManager();
+
+const running = computed(() => currentState.value === 'running');
+
+function togglePlayback() {
+  if (running.value) {
+    manager.suspend();
+  } else {
+    manager.resume();
+  }
+}
 </script>
 
 <template>
@@ -75,6 +94,18 @@ const {activeStacks, stateHistory, errorHistory, unlockHistory, playHistory} =
         </li>
       </ul>
     </div>
+
+    <div class="collapsed-border-row">
+      <IconAction
+        icon="unmuted"
+        icon-pressed="muted"
+        :label="running ? 'Suspend' : 'Resume'"
+        :a11y="`${running ? 'Suspend' : 'Resume'} the Earwurm`"
+        :pressed="running"
+        pressed-style
+        @action="togglePlayback"
+      />
+    </div>
   </section>
 </template>
 
@@ -99,6 +130,10 @@ const {activeStacks, stateHistory, errorHistory, unlockHistory, playHistory} =
   > .collapsed-border-row {
     position: relative;
     z-index: 1;
+  }
+
+  > .collapsed-border-row:last-child {
+    z-index: 3;
   }
 }
 

--- a/app/website/src/sections/StackControls.vue
+++ b/app/website/src/sections/StackControls.vue
@@ -42,7 +42,7 @@ const preparing = computed(() => hasStack.value && !loaded.value);
 <template>
   <article :id="`Stack-${id}`" class="StackControls collapsed-border-grid">
     <div class="collapsed-border-row">
-      <StackLabel :label="id" :populated="hasStack && loaded" />
+      <StackLabel :label="id" :populated="hasStack && loaded" truncate />
 
       <div v-if="hasStack" class="PopulatedBar collapsed-border-row">
         <div class="VolumeStackWrapper collapsed-border-row">

--- a/app/website/src/sections/index.ts
+++ b/app/website/src/sections/index.ts
@@ -5,4 +5,13 @@ import ManagerControls from './ManagerControls.vue';
 import SoundControls from './SoundControls.vue';
 import StackControls from './StackControls.vue';
 
-export {AppHeader, AppFooter, ManagerControls, SoundControls, StackControls};
+import ManagerDebug from './ManagerDebug.vue';
+
+export {
+  AppHeader,
+  AppFooter,
+  ManagerControls,
+  SoundControls,
+  StackControls,
+  ManagerDebug,
+};

--- a/app/website/src/store/index.ts
+++ b/app/website/src/store/index.ts
@@ -4,3 +4,5 @@ export {useThemeStore} from './useThemeStore';
 
 export {useStack} from './useStack';
 export {useSound} from './useSound';
+
+export {useDebugStore} from './useDebugStore';

--- a/app/website/src/store/index.ts
+++ b/app/website/src/store/index.ts
@@ -6,3 +6,4 @@ export {useStack} from './useStack';
 export {useSound} from './useSound';
 
 export {useDebugStore} from './useDebugStore';
+export {useDebugManager} from './useDebugManager';

--- a/app/website/src/store/useDebugManager.ts
+++ b/app/website/src/store/useDebugManager.ts
@@ -1,0 +1,70 @@
+import {computed, ref} from 'vue';
+import {type ManagerEventMap} from 'earwurm';
+
+import {useEarwurmStore} from './useEarwurmStore';
+
+type ErrorResponse = Parameters<ManagerEventMap['error']>[0];
+
+const MAX_HISTORY_LENGTH = 44;
+
+const {manager, activeStacks} = useEarwurmStore();
+
+const stateHistoryRef = ref([manager.state]);
+const errorHistoryRef = ref<ErrorResponse[]>([]);
+
+// TODO: Update these to be more accurate.
+// Currently, these do not update on the right events.
+const unlockHistoryRef = ref([manager.unlocked]);
+const playHistoryRef = ref([manager.playing]);
+
+function updateUnlockHistory() {
+  const currentLength = unlockHistoryRef.value.length;
+
+  if (manager.unlocked === unlockHistoryRef.value[currentLength - 1]) {
+    return;
+  }
+
+  const newHistory = [...unlockHistoryRef.value, manager.unlocked];
+  unlockHistoryRef.value = newHistory.slice(MAX_HISTORY_LENGTH * -1);
+}
+
+function updatePlayHistory() {
+  const currentLength = playHistoryRef.value.length;
+
+  if (manager.playing === playHistoryRef.value[currentLength - 1]) {
+    return;
+  }
+
+  const newHistory = [...playHistoryRef.value, manager.playing];
+  playHistoryRef.value = newHistory.slice(MAX_HISTORY_LENGTH * -1);
+}
+
+manager.on('state', (current) => {
+  const newState = [...stateHistoryRef.value, current];
+  stateHistoryRef.value = newState.slice(MAX_HISTORY_LENGTH * -1);
+
+  updateUnlockHistory();
+  updatePlayHistory();
+});
+
+manager.on('library', () => {
+  updateUnlockHistory();
+  updatePlayHistory();
+});
+
+manager.on('error', (response) => {
+  errorHistoryRef.value = [...errorHistoryRef.value, response];
+});
+
+export function useDebugManager() {
+  return {
+    activeStacks,
+    currentState: computed(
+      () => stateHistoryRef.value[stateHistoryRef.value.length - 1],
+    ),
+    stateHistory: computed(() => stateHistoryRef.value),
+    errorHistory: computed(() => errorHistoryRef.value),
+    unlockHistory: computed(() => unlockHistoryRef.value),
+    playHistory: computed(() => playHistoryRef.value),
+  };
+}

--- a/app/website/src/store/useDebugManager.ts
+++ b/app/website/src/store/useDebugManager.ts
@@ -7,6 +7,10 @@ type ErrorResponse = Parameters<ManagerEventMap['error']>[0];
 
 const MAX_HISTORY_LENGTH = 44;
 
+// TODO: Consider enabling a auto-suspension option.
+// import {clamp, timeMeasurement} from '@earwurm/utilities';
+// const safeAutoSuspend = clamp(0, autoSuspend, timeMeasurement.msPerMin);
+
 const {manager, activeStacks} = useEarwurmStore();
 
 const stateHistoryRef = ref([manager.state]);
@@ -35,10 +39,6 @@ manager.on('state', (current) => {
 manager.on('play', (active) => {
   const newPlayHistory = [...playHistoryRef.value, active];
   playHistoryRef.value = newPlayHistory.slice(MAX_HISTORY_LENGTH * -1);
-});
-
-manager.on('library', () => {
-  updateUnlockHistory();
 });
 
 manager.on('error', (response) => {

--- a/app/website/src/store/useDebugManager.ts
+++ b/app/website/src/store/useDebugManager.ts
@@ -11,9 +11,6 @@ const {manager, activeStacks} = useEarwurmStore();
 
 const stateHistoryRef = ref([manager.state]);
 const errorHistoryRef = ref<ErrorResponse[]>([]);
-
-// TODO: Update these to be more accurate.
-// Currently, these do not update on the right events.
 const unlockHistoryRef = ref([manager.unlocked]);
 const playHistoryRef = ref([manager.playing]);
 
@@ -28,28 +25,20 @@ function updateUnlockHistory() {
   unlockHistoryRef.value = newHistory.slice(MAX_HISTORY_LENGTH * -1);
 }
 
-function updatePlayHistory() {
-  const currentLength = playHistoryRef.value.length;
-
-  if (manager.playing === playHistoryRef.value[currentLength - 1]) {
-    return;
-  }
-
-  const newHistory = [...playHistoryRef.value, manager.playing];
-  playHistoryRef.value = newHistory.slice(MAX_HISTORY_LENGTH * -1);
-}
-
 manager.on('state', (current) => {
-  const newState = [...stateHistoryRef.value, current];
-  stateHistoryRef.value = newState.slice(MAX_HISTORY_LENGTH * -1);
+  const newStateHistory = [...stateHistoryRef.value, current];
+  stateHistoryRef.value = newStateHistory.slice(MAX_HISTORY_LENGTH * -1);
 
   updateUnlockHistory();
-  updatePlayHistory();
+});
+
+manager.on('play', (active) => {
+  const newPlayHistory = [...playHistoryRef.value, active];
+  playHistoryRef.value = newPlayHistory.slice(MAX_HISTORY_LENGTH * -1);
 });
 
 manager.on('library', () => {
   updateUnlockHistory();
-  updatePlayHistory();
 });
 
 manager.on('error', (response) => {

--- a/app/website/src/store/useDebugStore.ts
+++ b/app/website/src/store/useDebugStore.ts
@@ -1,0 +1,11 @@
+import {computed} from 'vue';
+
+function getSearchParams() {
+  const rawParams = window.location.search || '';
+  return new URLSearchParams(rawParams);
+}
+
+export function useDebugStore() {
+  const params = getSearchParams();
+  return computed(() => params.has('mode', 'debug'));
+}

--- a/app/website/src/store/useEarwurmStore.ts
+++ b/app/website/src/store/useEarwurmStore.ts
@@ -38,6 +38,13 @@ watch(managerVolumeRef, (incomingVolume) => {
   metroInstance.setVolume(manager.volume);
 });
 
+document.addEventListener('visibilitychange', () => {
+  // Pause all playing sounds when the device is interrupted.
+  if (document.hidden && manager.state === 'interrupted') {
+    activeStacksRef.value.forEach((stackId) => manager.get(stackId)?.pause());
+  }
+});
+
 export function useEarwurmStore() {
   return {
     audioLibrary,

--- a/app/website/src/styles/global.css
+++ b/app/website/src/styles/global.css
@@ -56,6 +56,14 @@ body {
   }
 }
 
+.collapsed-border-row--reverse {
+  display: flex;
+
+  > *:not(:last-child) {
+    margin-left: calc(var(--app-border-width) * -1);
+  }
+}
+
 /* --- Patterns --- */
 
 .pattern-arrows {

--- a/app/website/src/views/HomeView.vue
+++ b/app/website/src/views/HomeView.vue
@@ -1,6 +1,9 @@
 <script setup lang="ts">
 import {SynthTypeValues} from '@/types';
-import {ManagerControls, StackControls} from '@/sections';
+import {useDebugStore} from '@/store';
+import {ManagerDebug, ManagerControls, StackControls} from '@/sections';
+
+const debugging = useDebugStore();
 
 // TODO: Necessary so we can split our layout into two separate
 // "grid column" wrappers. Required until we have support for
@@ -13,6 +16,7 @@ const entries = [column1, column2];
 
 <template>
   <main class="HomeView">
+    <ManagerDebug v-if="debugging" />
     <ManagerControls />
 
     <section class="Stacks">

--- a/docs/api.md
+++ b/docs/api.md
@@ -38,6 +38,22 @@ manager.add({id: 'One', path: 'path/to/one.webm'}, ...moreEntries);
 // Remove entries from this instance, referenced by `Stack > id`.
 manager.remove('EntryId', ...moreEntryIds);
 
+// Manually resume `running` state for the `AudioContext`.
+// This does not guarantee the `AudioContext` will become “unlocked”.
+// For the most part, `.resume()` is managed behind the scenes, and
+// likely won’t be a method you ever require calling manually...
+// unless of course you have manually called `.suspend()`.
+manager.resume();
+
+// Can be used to force playback to a halt. This is like a global
+// “pause” for all sounds within the instance. Calling `.suspend()`
+// will not trigger any `state` events on the `Stack` or `Sound`
+// instances contained within. Unless you have a specific reason
+// to do so, it is recommended that you call `.pause()` on the
+// individual sounds instead. Earwurm will do its best to
+// suspend and resume the `AudioContext` behind the scenes.
+manager.suspend();
+
 // Stop and destory all sounds within each `Stack`.
 // Each `Stack` will remain available in the library
 // to continue interacting with.
@@ -125,13 +141,7 @@ manager.activeEvents;
 
 **Static members:**
 
-There are no static members. However, there are some relevant static values that can be retrieved from the exported `tokens` object:
-
-```ts
-// Retrieve the total time (in milliseconds) that needs
-// to pass before the auto-suspension kicks in.
-tokens.suspendAfterMs;
-```
+There are no static members or relevant tokens exposed at the `manager` level.
 
 ## Stack API
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -75,8 +75,21 @@ Publishing is handled automatically by the `@changesets` package. This package, 
 
 ## App
 
-To aid in local development, I have provided a demo application. This app doubles as our “marketing site”, which is also built-and-deployed through GitHub.
+To aid in local development, I have provided a demo application _(`app/website`)_. This app doubles as our “marketing site”, which is also built-and-deployed through GitHub.
 
 ### Development
 
-Simply run the `start` command from the project root and you will get file watching for `pkg/earwurm` as well as HMR for the app. Any changes you make to `earwurm` are automatically available to the demo app.
+Simply run the `start` command from the project root and you will get file watching for `pkg/earwurm` as well as HMR for the `website`. Any changes you make to `earwurm` are automatically available to the `website`.
+
+Your terminal should report the `localhost` address. Take note: since we host on `GitHub Pages`, the address will end with `/earwurm/`. Expect something like: `http://localhost:5173/earwurm/`.
+
+If you want to preview the production build of the `website`, you can run the following from the project root:
+
+```sh
+pnpm build
+pnpm --filter website preview
+```
+
+The `website` should now be available on a locally reachable address, allowing you to test on a `mobile` device.
+
+To help surface some additional details about the state history of the `Earwurm` instance, you can append the `?mode=debug` param to the end of the url. Something like: `http://localhost:5173/earwurm/?mode=debug`

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -6,7 +6,9 @@ The following examples should help demonstrate _most of the_ common use cases fo
 
 ## Getting started
 
-**Initialization:**
+Here are some basic examples to help initalize your `Earwurm` instance.
+
+### Initialization
 
 In order to start making noise, we will need to have an `Earwurm` instance to work with.
 
@@ -22,7 +24,7 @@ const sound = await stack?.prepare();
 sound?.play();
 ```
 
-**Enabling autoplay:**
+### Enabling autoplay
 
 Most browsers will intentionally block audio from playing automatically. The user should not be caught off guard with unwanted noise… annoying advertisements be damned! Any media should be explicitly initialized by the user.
 
@@ -38,7 +40,7 @@ manager.unlock();
 if (manager.unlocked) sound?.play();
 ```
 
-**Adding entries:**
+### Adding entries
 
 We can add as few as `1` new `Stack` at a time.
 
@@ -73,7 +75,7 @@ manager.add(
 // > ['Apple', 'Banana', 'Peach', 'Sprite']
 ```
 
-**Removing entries:**
+### Removing entries
 
 Similarly, we can remove any entries that have already been added:
 
@@ -93,9 +95,13 @@ manager.remove('Apple', 'Peach');
 // > ['Apple', 'Peach']
 ```
 
-**Auto suspend `AudioContext`:**
+### Auto suspend `AudioContext`
 
-By default, the `Earwurm > AudioContext` will continue `running` once it has begun playing sounds. That is unless the browser/device “interrupts” that playback, which can happen due to events such as putting your phone to sleep.
+`Earwurm` attempts to be efficient about managing `AudioContext` suspension by triggering a `suspend` if `.stop()` has been called on the `Earwurn` instance, or the `library` is empty _(`.remove()` has removed any remaining `Stack` instances)_.
+
+Otherwise, the `Earwurm > AudioContext` will continue `running` once it has begun playing sounds.
+
+> **Note:** There are instances where the browser/device can “interrupt” playback, causing `Earwurm` to emit an `interrupted` state change. Scenarios such as the device going to sleep, or receiving a phone call, invoke an “interruption”. This _should be_ functionally equivalent to the `suspended` state, and can be corrected by calling `.resume()`.
 
 To free up some precious resources, you can automatically `suspend` the `AudioContext` after a period of no playback. This is made easy by subscribing to the `Earwurn > play` event.
 
@@ -109,15 +115,12 @@ function autoSuspend() {
 }
 
 manager.on('play', (active) => {
-  if (active && suspendId) {
-    clearTimeout(suspendId);
-    suspendId = 0;
-    return;
-  }
+  clearTimeout(suspendId);
+  suspendId = 0;
 
-  if (!active) {
-    suspendId = setTimeout(autoSuspend, suspendAfterMs);
-  }
+  if (active) return;
+
+  suspendId = setTimeout(autoSuspend, suspendAfterMs);
 });
 ```
 
@@ -136,17 +139,7 @@ manager.on('state', (current) => {
 });
 ```
 
-Similarly, you may want to `suspend` the `AudioContext` if you no longer have any `Stack` instances.
-
-```ts
-manager.on('library', (newKeys) => {
-  // You could be even more aggresive by checking each
-  // `Stack > queue` to see if there are sounds.
-  if (newKeys.length === 0) manager.suspend();
-});
-```
-
-You may also want to perform some action - such as suspending the `AudioContext`, or pausing all sounds - if the page is no longer visible. The `document > visibilitychange` does not quite give us a way to distinguish between the many ways a page changes “visibility”... but it might be the catch-all the suits your needs.
+You may also want to perform some action - such as suspending the `AudioContext`, or pausing all sounds - if the page is no longer visible. The `document > visibilitychange` does not quite give us a way to distinguish between the many ways a page changes “visibility”... but it might be the catch-all that suits your needs.
 
 ```ts
 document.addEventListener('visibilitychange', () => {
@@ -158,9 +151,21 @@ document.addEventListener('visibilitychange', () => {
 });
 ```
 
+A good use-case for the above is restoring playback on a mobile device that went to sleep.
+
+```ts
+document.addEventListener('visibilitychange', () => {
+  if (!document.hidden && manager.state === 'interrupted') {
+    manager.resume();
+  }
+});
+```
+
 ## Using sounds
 
-**Interact with an available `Sound`:**
+Some more detailed examples for interacting with individual sounds.
+
+### Interact with an available `Sound`
 
 Now that we have added some audio files, let’s go ahead and play one.
 
@@ -199,7 +204,7 @@ const sound2 = stack?.prepare();
 if (sound2) sound2.then((soundInstance) => soundInstance.play());
 ```
 
-**Determining state values:**
+### Determining state values
 
 A `Stack` instance will have a dedicated `playing` property to help identify if _atleast one contained `Sound`_ is actively “playing”.
 
@@ -231,11 +236,11 @@ sound.on('state', (state) => {
 
 ## Sound behaviour
 
-As discussed in the `Design` document, sounds within the `AudioContext` are “one-and-done”. A `Sound` is “destroyed” upon completion.
+As discussed in the [Design document](./design.md), sounds within the `AudioContext` are “one-and-done”. A `Sound` is “destroyed” upon completion.
 
 Depending on our needs, we can tailor the behaviour in several ways.
 
-**Allowing sounds to overlap:**
+### Allowing sounds to overlap
 
 Every time we make a call to `.prepare()`, we “create a new instance” of that `Sound` within the `Stack`. After calling `.play()`, that `Sound` then “expires” and is removed from the `Stack` upon completion _(or call to `.stop()`)_.
 
@@ -258,7 +263,7 @@ async function handleOverlappingPlay() {
 return <Button onClick={handleOverlappingPlay}>Overlap</Button>;
 ```
 
-**Restricting a `Sound` to a single instance:**
+### Restricting a `Sound` to a single instance
 
 If we do not want consecutive plays of a `Sound` to overlap, we can restrict the `Stack` to allow only a single `Sound` in the `queue` at once. Simply checking for `stack.keys.length` will let us know how many sounds have been queued up.
 
@@ -302,7 +307,7 @@ async function handleSinglePlay() {
 }
 ```
 
-**Restarting a playing `Sound`:**
+### Restarting a playing `Sound`
 
 A variation of the “One-at-a-time pattern” is the “Restart pattern”. Here, we will check if the `Sound` is `playing`, and if `true`, simply “restart it” from the beginning:
 
@@ -326,7 +331,7 @@ function handleRestartPlay() {
 return <Button onClick={handleRestartPlay}>Restart</Button>;
 ```
 
-**Restricting a specific `Sound` in the `Stack`:**
+### Restricting a specific `Sound` in the `Stack`
 
 If we are re-using the same `Sound` in multiple places throughout the app, it could be beneficial to re-use the same variable reference.
 
@@ -350,7 +355,7 @@ function handleSoundPlay() {
 return <Button onClick={handleSinglePlay}>Single</Button>;
 ```
 
-**Managing a `Sound` queue:**
+### Managing a `Sound` queue
 
 The problem with the “One-at-a-time” pattern is that it prevents adding a `Sound` to the `stack.queue` if `state` is `playing`. If the behaviour we _really want_ is to queue up a sound to play as soon as `state` is no longer `playing`, we can utilize the “Wait-your-turn pattern”:
 
@@ -415,7 +420,7 @@ async function handleQueuedPlay() {
 return <Button onClick={handleQueuedPlay}>Queue and play</Button>;
 ```
 
-**Stopping after an elapsed play time:**
+### Stopping after an elapsed play time
 
 ```ts
 const stack = manager.get('MyStack');
@@ -450,7 +455,7 @@ if (sound) {
 }
 ```
 
-**Looping audio:**
+### Looping audio
 
 We can easily toggle a `Sound` to “loop indefinitely” by the `sound.loop` accessor.
 
@@ -476,4 +481,6 @@ if (sound) {
 
 ## Summary
 
-Hopefully this document has provided enough examples to help you identify the capabilities of `earwurm`. If you are anxious to start experimenting, please check out the included demo app within this repo!
+Hopefully this document has provided enough examples to help you identify the capabilities of `Earwurm`. If you are anxious to start experimenting, please check out the included demo app within this repo!
+
+If you end up experimenting with `Earwurm` and have a `CodeSandbox` to share, feel free to [open an issue](https://github.com/beefchimi/earwurm/issues) and post the link so other consumers can learn from it.

--- a/package.json
+++ b/package.json
@@ -16,9 +16,9 @@
   "private": true,
   "engines": {
     "node": ">=20.10.0",
-    "pnpm": ">=8.14.0"
+    "pnpm": ">=8.15.0"
   },
-  "packageManager": "pnpm@8.14.0",
+  "packageManager": "pnpm@8.15.0",
   "scripts": {
     "clean": "pnpm -r clean && rm -rf coverage",
     "nuke": "pnpm clean && ./scripts/nuke.sh",
@@ -39,10 +39,10 @@
   "devDependencies": {
     "@changesets/changelog-github": "^0.5.0",
     "@changesets/cli": "^2.27.1",
-    "@types/node": "^20.11.5",
+    "@types/node": "^20.11.8",
     "@typescript-eslint/eslint-plugin": "^6.19.1",
-    "@vitest/coverage-v8": "^1.2.1",
-    "@vitest/ui": "^1.2.1",
+    "@vitest/coverage-v8": "^1.2.2",
+    "@vitest/ui": "^1.2.2",
     "eslint": "^8.56.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-config-standard-with-typescript": "^43.0.1",
@@ -50,10 +50,10 @@
     "eslint-plugin-n": "^16.6.2",
     "eslint-plugin-prettier": "^5.1.3",
     "eslint-plugin-promise": "^6.1.1",
-    "happy-dom": "^13.2.1",
+    "happy-dom": "^13.3.1",
     "prettier": "^3.2.4",
     "typescript": "^5.3.3",
     "vite": "^5.0.12",
-    "vitest": "^1.2.1"
+    "vitest": "^1.2.2"
   }
 }

--- a/pkg/earwurm/MIGRATION.md
+++ b/pkg/earwurm/MIGRATION.md
@@ -1,5 +1,16 @@
 # Earwurm Migration Guide
 
+## 0.9.0
+
+- Removed the “timed auto-suspend” behaviour.
+  - With the new `play` event, it is now easy for consumers to specify this behaviour themselves.
+  - See the `Examples` documentation for some insight.
+  - PR for code change: <https://github.com/beefchimi/earwurm/pull/78>
+- While there is no more “timed auto-suspend”, the `Earwurm` will attempt to optimistically `suspend` whenever:
+  - All `Stacks` have been removed from the `Earwurm`. instance.
+  - `.stop()` has been called on the `Earwurn` instance.
+- Will now auto-resume a `suspended` state when `.play()` is called on a `Sound`.
+
 ## 0.7.0
 
 - Replaced the `fadeMs?: number` option for `Earwurm`, `Stack`, and `Sound` with a simpler `transitions?: boolean` option.

--- a/pkg/earwurm/package.json
+++ b/pkg/earwurm/package.json
@@ -39,7 +39,7 @@
   },
   "engines": {
     "node": ">=20.10.0",
-    "pnpm": ">=8.14.0"
+    "pnpm": ">=8.15.0"
   },
   "scripts": {
     "clean": "rm -rf dist",
@@ -56,7 +56,7 @@
     "@earwurm/types": "workspace:*",
     "@earwurm/utilities": "workspace:*",
     "vite": "^5.0.12",
-    "vite-plugin-dts": "^3.7.1"
+    "vite-plugin-dts": "^3.7.2"
   },
   "peerDependencies": {
     "emitten": "^0.6.3"

--- a/pkg/earwurm/src/Earwurm.ts
+++ b/pkg/earwurm/src/Earwurm.ts
@@ -214,12 +214,13 @@ export class Earwurm extends EmittenCommon<ManagerEventMap> {
       this.#setState('suspended');
     };
 
-    // The `state` either gets `suspended` or `interrupted`...
-    // Either way, we need to update the state to `suspended`.
     this.#context
       .suspend()
       .then(resolveSuspension)
       .catch((error) => {
+        // The `state` either gets `suspended` or `interrupted`...
+        // Either way, we need to update the state to `suspended`,
+        // so we call `resolveSuspension()` even when it encounters an error.
         resolveSuspension();
         this.emit('error', [tokens.error.suspend, getErrorMessage(error)]);
       });
@@ -264,6 +265,7 @@ export class Earwurm extends EmittenCommon<ManagerEventMap> {
     this._keys = newKeys;
 
     if (!identicalKeys) this.emit('library', newKeys, oldKeys);
+    if (newKeys.length === 0) this.suspend();
   }
 
   #setState(value: ManagerState) {

--- a/pkg/earwurm/src/Earwurm.ts
+++ b/pkg/earwurm/src/Earwurm.ts
@@ -272,13 +272,14 @@ export class Earwurm extends EmittenCommon<ManagerEventMap> {
     if (this._state === value) return;
 
     this._state = value;
-    this.emit('state', value);
 
     if (value === 'running') {
       this._unlocked = true;
     } else if (value === 'closed') {
       this._unlocked = false;
     }
+
+    this.emit('state', value);
   }
 
   readonly #handleStateChange = () => {
@@ -291,9 +292,10 @@ export class Earwurm extends EmittenCommon<ManagerEventMap> {
   readonly #handleStackState: StackEventMap['state'] = (_current) => {
     const isPlaying = this.playing;
 
-    if (isPlaying !== this._playing) {
-      this._playing = isPlaying;
-      this.emit('play', isPlaying);
-    }
+    if (isPlaying === this._playing) return;
+    if (isPlaying) this.resume();
+
+    this._playing = isPlaying;
+    this.emit('play', isPlaying);
   };
 }

--- a/pkg/earwurm/src/tests/Earwurm.test.ts
+++ b/pkg/earwurm/src/tests/Earwurm.test.ts
@@ -426,9 +426,7 @@ describe('Earwurm component', () => {
   describe('resume()', () => {
     const clickEvent = new Event('click');
 
-    // TODO: Our mocked setup doesn’t actually know how to
-    // update the `context.state` when a sound is played.
-    it.skip('resumes once a `Sound` plays', async () => {
+    it('resumes once a `Sound` plays', async () => {
       managerSetup(mockManager, mockEntries);
 
       const stack0 = mockManager.get(mockEntries[0].id);
@@ -732,6 +730,26 @@ describe('Earwurm component', () => {
         expect(spyPlay).toHaveBeenNthCalledWith(2, false);
 
         expect(spyPlay).not.toBeCalledTimes(3);
+      });
+
+      it('does not trigger a 2nd time when the state hasnt changed', async () => {
+        const spyPlay: ManagerEventMap['play'] = vi.fn((_active) => {});
+        mockManager.on('play', spyPlay);
+
+        managerSetup(mockManager, mockEntries);
+
+        const stack0 = mockManager.get(mockEntries[0].id);
+        const stack0Sound = await stack0?.prepare();
+
+        expect(spyPlay).not.toBeCalled();
+        stack0Sound?.play();
+        expect(spyPlay).toHaveBeenNthCalledWith(1, true);
+
+        const stack1 = mockManager.get(mockEntries[1].id);
+        const stack1Sound = await stack1?.prepare();
+        stack1Sound?.play();
+
+        expect(spyPlay).not.toBeCalledTimes(2);
       });
     });
   });

--- a/pkg/earwurm/src/tests/helpers.ts
+++ b/pkg/earwurm/src/tests/helpers.ts
@@ -1,0 +1,23 @@
+import {mockData} from '@earwurm/mocks';
+
+import type {Earwurm} from '../Earwurm';
+import type {LibraryEntry, StackId} from '../types';
+
+export const mockEntries: LibraryEntry[] = [
+  {id: 'Zero', path: mockData.audio},
+  {id: 'One', path: 'to/no/file.mp3'},
+  {id: 'Two', path: ''},
+];
+
+export const mockInitialKeys: StackId[] = mockEntries.map(({id}) => id);
+
+export function managerSetup(
+  earwurmInstance: Earwurm,
+  library: LibraryEntry[],
+) {
+  earwurmInstance.add(...library);
+  earwurmInstance.unlock();
+
+  const clickEvent = new Event('click');
+  document.dispatchEvent(clickEvent);
+}

--- a/pkg/earwurm/src/tokens.ts
+++ b/pkg/earwurm/src/tokens.ts
@@ -6,10 +6,6 @@ export const tokens = {
     suspend: 'Encountered an error during Earwurm suspension.',
   },
   transitionSec: 0.2,
-
-  // Earwurm (manager)
-  // suspendAfterMs: 30000,
-
   // Stack
   maxStackSize: 8,
   // Sound

--- a/pkg/earwurm/src/tokens.ts
+++ b/pkg/earwurm/src/tokens.ts
@@ -3,10 +3,13 @@ export const tokens = {
   error: {
     close: 'Failed to close the Earwurm AudioContext.',
     resume: 'Failed to resume the Earwurm AudioContext.',
+    suspend: 'Encountered an error during Earwurm suspension.',
   },
   transitionSec: 0.2,
+
   // Earwurm (manager)
-  suspendAfterMs: 30000,
+  // suspendAfterMs: 30000,
+
   // Stack
   maxStackSize: 8,
   // Sound

--- a/pkg/earwurm/src/types.ts
+++ b/pkg/earwurm/src/types.ts
@@ -5,6 +5,7 @@ export type ManagerState = AudioContextState | 'suspending' | 'interrupted';
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export type ManagerEventMap = {
   state: (current: ManagerState) => void;
+  play: (active: boolean) => void;
   library: (newKeys: StackId[], oldKeys: StackId[]) => void;
   volume: (level: number) => void;
   mute: (muted: boolean) => void;

--- a/pkg/helpers/package.json
+++ b/pkg/helpers/package.json
@@ -5,7 +5,7 @@
   "license": "ISC",
   "engines": {
     "node": ">=20.10.0",
-    "pnpm": ">=8.14.0"
+    "pnpm": ">=8.15.0"
   },
   "dependencies": {},
   "devDependencies": {

--- a/pkg/helpers/unlock-audio-context.ts
+++ b/pkg/helpers/unlock-audio-context.ts
@@ -14,10 +14,8 @@ export function unlockAudioContext(
   const buffer = scratchBuffer(context);
 
   function unlock() {
-    // TODO: Double-check and make sure this is still required.
+    // TODO: Double-check and make sure this is still required:
     // Android can not play in suspend state.
-    // We might want to use `autoResume()` here,
-    // and if so, will need a `.onStart?()`.
     context.resume().catch(() => null);
 
     const source = context.createBufferSource();

--- a/pkg/mocks/package.json
+++ b/pkg/mocks/package.json
@@ -5,7 +5,7 @@
   "license": "ISC",
   "engines": {
     "node": ">=20.10.0",
-    "pnpm": ">=8.14.0"
+    "pnpm": ">=8.15.0"
   },
   "dependencies": {
     "@earwurm/utilities": "workspace:*"

--- a/pkg/types/package.json
+++ b/pkg/types/package.json
@@ -5,7 +5,7 @@
   "license": "ISC",
   "engines": {
     "node": ">=20.10.0",
-    "pnpm": ">=8.14.0"
+    "pnpm": ">=8.15.0"
   },
   "dependencies": {},
   "devDependencies": {}

--- a/pkg/utilities/package.json
+++ b/pkg/utilities/package.json
@@ -5,7 +5,7 @@
   "license": "ISC",
   "engines": {
     "node": ">=20.10.0",
-    "pnpm": ">=8.14.0"
+    "pnpm": ">=8.15.0"
   },
   "dependencies": {
     "@earwurm/types": "workspace:*"

--- a/pkg/utilities/support.ts
+++ b/pkg/utilities/support.ts
@@ -3,6 +3,7 @@ export function supportDom() {
 }
 
 export function supportMatchMedia() {
-  return () =>
-    window && 'matchMedia' in window && typeof window.matchMedia === 'function';
+  return (
+    window && 'matchMedia' in window && typeof window.matchMedia === 'function'
+  );
 }

--- a/pkg/utilities/tests/support.test.ts
+++ b/pkg/utilities/tests/support.test.ts
@@ -12,8 +12,8 @@ describe('support utilities', () => {
 
   describe('supportMatchMedia()', () => {
     it('returns true in this test environment', async () => {
-      const resultFunction = supportMatchMedia();
-      expect(resultFunction()).toBe(true);
+      const result = supportMatchMedia();
+      expect(result).toBe(true);
     });
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,17 +15,17 @@ importers:
         specifier: ^2.27.1
         version: 2.27.1
       '@types/node':
-        specifier: ^20.11.5
-        version: 20.11.5
+        specifier: ^20.11.8
+        version: 20.11.8
       '@typescript-eslint/eslint-plugin':
         specifier: ^6.19.1
         version: 6.19.1(@typescript-eslint/parser@6.19.1)(eslint@8.56.0)(typescript@5.3.3)
       '@vitest/coverage-v8':
-        specifier: ^1.2.1
-        version: 1.2.1(vitest@1.2.1)
+        specifier: ^1.2.2
+        version: 1.2.2(vitest@1.2.2)
       '@vitest/ui':
-        specifier: ^1.2.1
-        version: 1.2.1(vitest@1.2.1)
+        specifier: ^1.2.2
+        version: 1.2.2(vitest@1.2.2)
       eslint:
         specifier: ^8.56.0
         version: 8.56.0
@@ -48,8 +48,8 @@ importers:
         specifier: ^6.1.1
         version: 6.1.1(eslint@8.56.0)
       happy-dom:
-        specifier: ^13.2.1
-        version: 13.2.1
+        specifier: ^13.3.1
+        version: 13.3.1
       prettier:
         specifier: ^3.2.4
         version: 3.2.4
@@ -58,10 +58,10 @@ importers:
         version: 5.3.3
       vite:
         specifier: ^5.0.12
-        version: 5.0.12(@types/node@20.11.5)(lightningcss@1.23.0)
+        version: 5.0.12(@types/node@20.11.8)(lightningcss@1.23.0)
       vitest:
-        specifier: ^1.2.1
-        version: 1.2.1(@types/node@20.11.5)(@vitest/ui@1.2.1)(happy-dom@13.2.1)
+        specifier: ^1.2.2
+        version: 1.2.2(@types/node@20.11.8)(@vitest/ui@1.2.2)(happy-dom@13.3.1)
 
   app/website:
     dependencies:
@@ -79,8 +79,8 @@ importers:
         specifier: workspace:*
         version: link:../../pkg/types
       '@rushstack/eslint-patch':
-        specifier: ^1.7.0
-        version: 1.7.0
+        specifier: ^1.7.2
+        version: 1.7.2
       '@tsconfig/node20':
         specifier: ^20.1.2
         version: 20.1.2
@@ -129,10 +129,10 @@ importers:
         version: link:../utilities
       vite:
         specifier: ^5.0.12
-        version: 5.0.12(@types/node@20.11.5)(lightningcss@1.23.0)
+        version: 5.0.12(@types/node@20.11.8)(lightningcss@1.23.0)
       vite-plugin-dts:
-        specifier: ^3.7.1
-        version: 3.7.1(@types/node@20.11.5)(typescript@5.3.3)(vite@5.0.12)
+        specifier: ^3.7.2
+        version: 3.7.2(@types/node@20.11.8)(typescript@5.3.3)(vite@5.0.12)
 
   pkg/helpers:
     devDependencies:
@@ -194,22 +194,22 @@ packages:
       js-tokens: 4.0.0
     dev: true
 
-  /@babel/parser@7.23.6:
-    resolution: {integrity: sha512-Z2uID7YJ7oNvAI20O9X0bblw7Qqs8Q2hFy0R9tAfnfLkp5MW0UH9eUvnDSnFwKZ0AvgS1ucqR4KzvVHgnke1VQ==}
+  /@babel/parser@7.23.9:
+    resolution: {integrity: sha512-9tcKgqKbs3xGJ+NtKF2ndOBBLVwPjl1SHxPQkd36r3Dlirw3xWUeGaTbqr7uGZcTaxkVNwc+03SVP7aCdWrTlA==}
     engines: {node: '>=6.0.0'}
     hasBin: true
     dependencies:
-      '@babel/types': 7.23.6
+      '@babel/types': 7.23.9
 
-  /@babel/runtime@7.23.8:
-    resolution: {integrity: sha512-Y7KbAP984rn1VGMbGqKmBLio9V7y5Je9GvU4rQPCPinCyNfUcToxIXl06d59URp/F3LwinvODxab5N/G6qggkw==}
+  /@babel/runtime@7.23.9:
+    resolution: {integrity: sha512-0CX6F+BI2s9dkUqr08KFrAIZgNFj75rdBU/DjCyYLIaV/quFjkk6T+EJ2LkZHyZTbEV4L5p97mNkUsHl2wLFAw==}
     engines: {node: '>=6.9.0'}
     dependencies:
       regenerator-runtime: 0.14.1
     dev: true
 
-  /@babel/types@7.23.6:
-    resolution: {integrity: sha512-+uarb83brBzPKN38NX1MkB6vb6+mwvR6amUulqAE7ccQw1pEl+bCia9TbdG1lsnFP7lZySvUn37CHyXQdfTwzg==}
+  /@babel/types@7.23.9:
+    resolution: {integrity: sha512-dQjSq/7HaSjRM43FFGnv5keM2HsxpmyV1PfaSVm0nzzjwwTmjOe6J4bC8e3+pTEIgHaHj+1ZlLThRJ2auc/w1Q==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/helper-string-parser': 7.23.4
@@ -223,7 +223,7 @@ packages:
   /@changesets/apply-release-plan@7.0.0:
     resolution: {integrity: sha512-vfi69JR416qC9hWmFGSxj7N6wA5J222XNBmezSVATPWDVPIF7gkd4d8CpbEbXmRWbVrkoli3oerGS6dcL/BGsQ==}
     dependencies:
-      '@babel/runtime': 7.23.8
+      '@babel/runtime': 7.23.9
       '@changesets/config': 3.0.0
       '@changesets/get-version-range-type': 0.4.0
       '@changesets/git': 3.0.0
@@ -241,7 +241,7 @@ packages:
   /@changesets/assemble-release-plan@6.0.0:
     resolution: {integrity: sha512-4QG7NuisAjisbW4hkLCmGW2lRYdPrKzro+fCtZaILX+3zdUELSvYjpL4GTv0E4aM9Mef3PuIQp89VmHJ4y2bfw==}
     dependencies:
-      '@babel/runtime': 7.23.8
+      '@babel/runtime': 7.23.9
       '@changesets/errors': 0.2.0
       '@changesets/get-dependents-graph': 2.0.0
       '@changesets/types': 6.0.0
@@ -269,7 +269,7 @@ packages:
     resolution: {integrity: sha512-iJ91xlvRnnrJnELTp4eJJEOPjgpF3NOh4qeQehM6Ugiz9gJPRZ2t+TsXun6E3AMN4hScZKjqVXl0TX+C7AB3ZQ==}
     hasBin: true
     dependencies:
-      '@babel/runtime': 7.23.8
+      '@babel/runtime': 7.23.9
       '@changesets/apply-release-plan': 7.0.0
       '@changesets/assemble-release-plan': 6.0.0
       '@changesets/changelog-git': 0.2.0
@@ -343,7 +343,7 @@ packages:
   /@changesets/get-release-plan@4.0.0:
     resolution: {integrity: sha512-9L9xCUeD/Tb6L/oKmpm8nyzsOzhdNBBbt/ZNcjynbHC07WW4E1eX8NMGC5g5SbM5z/V+MOrYsJ4lRW41GCbg3w==}
     dependencies:
-      '@babel/runtime': 7.23.8
+      '@babel/runtime': 7.23.9
       '@changesets/assemble-release-plan': 6.0.0
       '@changesets/config': 3.0.0
       '@changesets/pre': 2.0.0
@@ -359,7 +359,7 @@ packages:
   /@changesets/git@3.0.0:
     resolution: {integrity: sha512-vvhnZDHe2eiBNRFHEgMiGd2CT+164dfYyrJDhwwxTVD/OW0FUD6G7+4DIx1dNwkwjHyzisxGAU96q0sVNBns0w==}
     dependencies:
-      '@babel/runtime': 7.23.8
+      '@babel/runtime': 7.23.9
       '@changesets/errors': 0.2.0
       '@changesets/types': 6.0.0
       '@manypkg/get-packages': 1.1.3
@@ -384,7 +384,7 @@ packages:
   /@changesets/pre@2.0.0:
     resolution: {integrity: sha512-HLTNYX/A4jZxc+Sq8D1AMBsv+1qD6rmmJtjsCJa/9MSRybdxh0mjbTvE6JYZQ/ZiQ0mMlDOlGPXTm9KLTU3jyw==}
     dependencies:
-      '@babel/runtime': 7.23.8
+      '@babel/runtime': 7.23.9
       '@changesets/errors': 0.2.0
       '@changesets/types': 6.0.0
       '@manypkg/get-packages': 1.1.3
@@ -394,7 +394,7 @@ packages:
   /@changesets/read@0.6.0:
     resolution: {integrity: sha512-ZypqX8+/im1Fm98K4YcZtmLKgjs1kDQ5zHpc2U1qdtNBmZZfo/IBiG162RoP0CUF05tvp2y4IspH11PLnPxuuw==}
     dependencies:
-      '@babel/runtime': 7.23.8
+      '@babel/runtime': 7.23.9
       '@changesets/git': 3.0.0
       '@changesets/logger': 0.1.0
       '@changesets/parse': 0.4.0
@@ -415,15 +415,15 @@ packages:
   /@changesets/write@0.3.0:
     resolution: {integrity: sha512-slGLb21fxZVUYbyea+94uFiD6ntQW0M2hIKNznFizDhZPDgn2c/fv1UzzlW43RVzh1BEDuIqW6hzlJ1OflNmcw==}
     dependencies:
-      '@babel/runtime': 7.23.8
+      '@babel/runtime': 7.23.9
       '@changesets/types': 6.0.0
       fs-extra: 7.0.1
       human-id: 1.0.2
       prettier: 2.8.8
     dev: true
 
-  /@esbuild/aix-ppc64@0.19.11:
-    resolution: {integrity: sha512-FnzU0LyE3ySQk7UntJO4+qIiQgI7KoODnZg5xzXIrFJlKd2P2gwHsHY4927xj9y5PJmJSzULiUCWmv7iWnNa7g==}
+  /@esbuild/aix-ppc64@0.19.12:
+    resolution: {integrity: sha512-bmoCYyWdEL3wDQIVbcyzRyeKLgk2WtWLTWz1ZIAZF/EGbNOwSA6ew3PftJ1PqMiOOGu0OyFMzG53L0zqIpPeNA==}
     engines: {node: '>=12'}
     cpu: [ppc64]
     os: [aix]
@@ -431,8 +431,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/android-arm64@0.19.11:
-    resolution: {integrity: sha512-aiu7K/5JnLj//KOnOfEZ0D90obUkRzDMyqd/wNAUQ34m4YUPVhRZpnqKV9uqDGxT7cToSDnIHsGooyIczu9T+Q==}
+  /@esbuild/android-arm64@0.19.12:
+    resolution: {integrity: sha512-P0UVNGIienjZv3f5zq0DP3Nt2IE/3plFzuaS96vihvD0Hd6H/q4WXUGpCxD/E8YrSXfNyRPbpTq+T8ZQioSuPA==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [android]
@@ -440,8 +440,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/android-arm@0.19.11:
-    resolution: {integrity: sha512-5OVapq0ClabvKvQ58Bws8+wkLCV+Rxg7tUVbo9xu034Nm536QTII4YzhaFriQ7rMrorfnFKUsArD2lqKbFY4vw==}
+  /@esbuild/android-arm@0.19.12:
+    resolution: {integrity: sha512-qg/Lj1mu3CdQlDEEiWrlC4eaPZ1KztwGJ9B6J+/6G+/4ewxJg7gqj8eVYWvao1bXrqGiW2rsBZFSX3q2lcW05w==}
     engines: {node: '>=12'}
     cpu: [arm]
     os: [android]
@@ -449,8 +449,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/android-x64@0.19.11:
-    resolution: {integrity: sha512-eccxjlfGw43WYoY9QgB82SgGgDbibcqyDTlk3l3C0jOVHKxrjdc9CTwDUQd0vkvYg5um0OH+GpxYvp39r+IPOg==}
+  /@esbuild/android-x64@0.19.12:
+    resolution: {integrity: sha512-3k7ZoUW6Q6YqhdhIaq/WZ7HwBpnFBlW905Fa4s4qWJyiNOgT1dOqDiVAQFwBH7gBRZr17gLrlFCRzF6jFh7Kew==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [android]
@@ -458,8 +458,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/darwin-arm64@0.19.11:
-    resolution: {integrity: sha512-ETp87DRWuSt9KdDVkqSoKoLFHYTrkyz2+65fj9nfXsaV3bMhTCjtQfw3y+um88vGRKRiF7erPrh/ZuIdLUIVxQ==}
+  /@esbuild/darwin-arm64@0.19.12:
+    resolution: {integrity: sha512-B6IeSgZgtEzGC42jsI+YYu9Z3HKRxp8ZT3cqhvliEHovq8HSX2YX8lNocDn79gCKJXOSaEot9MVYky7AKjCs8g==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [darwin]
@@ -467,8 +467,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/darwin-x64@0.19.11:
-    resolution: {integrity: sha512-fkFUiS6IUK9WYUO/+22omwetaSNl5/A8giXvQlcinLIjVkxwTLSktbF5f/kJMftM2MJp9+fXqZ5ezS7+SALp4g==}
+  /@esbuild/darwin-x64@0.19.12:
+    resolution: {integrity: sha512-hKoVkKzFiToTgn+41qGhsUJXFlIjxI/jSYeZf3ugemDYZldIXIxhvwN6erJGlX4t5h417iFuheZ7l+YVn05N3A==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [darwin]
@@ -476,8 +476,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/freebsd-arm64@0.19.11:
-    resolution: {integrity: sha512-lhoSp5K6bxKRNdXUtHoNc5HhbXVCS8V0iZmDvyWvYq9S5WSfTIHU2UGjcGt7UeS6iEYp9eeymIl5mJBn0yiuxA==}
+  /@esbuild/freebsd-arm64@0.19.12:
+    resolution: {integrity: sha512-4aRvFIXmwAcDBw9AueDQ2YnGmz5L6obe5kmPT8Vd+/+x/JMVKCgdcRwH6APrbpNXsPz+K653Qg8HB/oXvXVukA==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [freebsd]
@@ -485,8 +485,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/freebsd-x64@0.19.11:
-    resolution: {integrity: sha512-JkUqn44AffGXitVI6/AbQdoYAq0TEullFdqcMY/PCUZ36xJ9ZJRtQabzMA+Vi7r78+25ZIBosLTOKnUXBSi1Kw==}
+  /@esbuild/freebsd-x64@0.19.12:
+    resolution: {integrity: sha512-EYoXZ4d8xtBoVN7CEwWY2IN4ho76xjYXqSXMNccFSx2lgqOG/1TBPW0yPx1bJZk94qu3tX0fycJeeQsKovA8gg==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [freebsd]
@@ -494,8 +494,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-arm64@0.19.11:
-    resolution: {integrity: sha512-LneLg3ypEeveBSMuoa0kwMpCGmpu8XQUh+mL8XXwoYZ6Be2qBnVtcDI5azSvh7vioMDhoJFZzp9GWp9IWpYoUg==}
+  /@esbuild/linux-arm64@0.19.12:
+    resolution: {integrity: sha512-EoTjyYyLuVPfdPLsGVVVC8a0p1BFFvtpQDB/YLEhaXyf/5bczaGeN15QkR+O4S5LeJ92Tqotve7i1jn35qwvdA==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [linux]
@@ -503,8 +503,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-arm@0.19.11:
-    resolution: {integrity: sha512-3CRkr9+vCV2XJbjwgzjPtO8T0SZUmRZla+UL1jw+XqHZPkPgZiyWvbDvl9rqAN8Zl7qJF0O/9ycMtjU67HN9/Q==}
+  /@esbuild/linux-arm@0.19.12:
+    resolution: {integrity: sha512-J5jPms//KhSNv+LO1S1TX1UWp1ucM6N6XuL6ITdKWElCu8wXP72l9MM0zDTzzeikVyqFE6U8YAV9/tFyj0ti+w==}
     engines: {node: '>=12'}
     cpu: [arm]
     os: [linux]
@@ -512,8 +512,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-ia32@0.19.11:
-    resolution: {integrity: sha512-caHy++CsD8Bgq2V5CodbJjFPEiDPq8JJmBdeyZ8GWVQMjRD0sU548nNdwPNvKjVpamYYVL40AORekgfIubwHoA==}
+  /@esbuild/linux-ia32@0.19.12:
+    resolution: {integrity: sha512-Thsa42rrP1+UIGaWz47uydHSBOgTUnwBwNq59khgIwktK6x60Hivfbux9iNR0eHCHzOLjLMLfUMLCypBkZXMHA==}
     engines: {node: '>=12'}
     cpu: [ia32]
     os: [linux]
@@ -521,8 +521,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-loong64@0.19.11:
-    resolution: {integrity: sha512-ppZSSLVpPrwHccvC6nQVZaSHlFsvCQyjnvirnVjbKSHuE5N24Yl8F3UwYUUR1UEPaFObGD2tSvVKbvR+uT1Nrg==}
+  /@esbuild/linux-loong64@0.19.12:
+    resolution: {integrity: sha512-LiXdXA0s3IqRRjm6rV6XaWATScKAXjI4R4LoDlvO7+yQqFdlr1Bax62sRwkVvRIrwXxvtYEHHI4dm50jAXkuAA==}
     engines: {node: '>=12'}
     cpu: [loong64]
     os: [linux]
@@ -530,8 +530,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-mips64el@0.19.11:
-    resolution: {integrity: sha512-B5x9j0OgjG+v1dF2DkH34lr+7Gmv0kzX6/V0afF41FkPMMqaQ77pH7CrhWeR22aEeHKaeZVtZ6yFwlxOKPVFyg==}
+  /@esbuild/linux-mips64el@0.19.12:
+    resolution: {integrity: sha512-fEnAuj5VGTanfJ07ff0gOA6IPsvrVHLVb6Lyd1g2/ed67oU1eFzL0r9WL7ZzscD+/N6i3dWumGE1Un4f7Amf+w==}
     engines: {node: '>=12'}
     cpu: [mips64el]
     os: [linux]
@@ -539,8 +539,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-ppc64@0.19.11:
-    resolution: {integrity: sha512-MHrZYLeCG8vXblMetWyttkdVRjQlQUb/oMgBNurVEnhj4YWOr4G5lmBfZjHYQHHN0g6yDmCAQRR8MUHldvvRDA==}
+  /@esbuild/linux-ppc64@0.19.12:
+    resolution: {integrity: sha512-nYJA2/QPimDQOh1rKWedNOe3Gfc8PabU7HT3iXWtNUbRzXS9+vgB0Fjaqr//XNbd82mCxHzik2qotuI89cfixg==}
     engines: {node: '>=12'}
     cpu: [ppc64]
     os: [linux]
@@ -548,8 +548,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-riscv64@0.19.11:
-    resolution: {integrity: sha512-f3DY++t94uVg141dozDu4CCUkYW+09rWtaWfnb3bqe4w5NqmZd6nPVBm+qbz7WaHZCoqXqHz5p6CM6qv3qnSSQ==}
+  /@esbuild/linux-riscv64@0.19.12:
+    resolution: {integrity: sha512-2MueBrlPQCw5dVJJpQdUYgeqIzDQgw3QtiAHUC4RBz9FXPrskyyU3VI1hw7C0BSKB9OduwSJ79FTCqtGMWqJHg==}
     engines: {node: '>=12'}
     cpu: [riscv64]
     os: [linux]
@@ -557,8 +557,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-s390x@0.19.11:
-    resolution: {integrity: sha512-A5xdUoyWJHMMlcSMcPGVLzYzpcY8QP1RtYzX5/bS4dvjBGVxdhuiYyFwp7z74ocV7WDc0n1harxmpq2ePOjI0Q==}
+  /@esbuild/linux-s390x@0.19.12:
+    resolution: {integrity: sha512-+Pil1Nv3Umes4m3AZKqA2anfhJiVmNCYkPchwFJNEJN5QxmTs1uzyy4TvmDrCRNT2ApwSari7ZIgrPeUx4UZDg==}
     engines: {node: '>=12'}
     cpu: [s390x]
     os: [linux]
@@ -566,8 +566,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-x64@0.19.11:
-    resolution: {integrity: sha512-grbyMlVCvJSfxFQUndw5mCtWs5LO1gUlwP4CDi4iJBbVpZcqLVT29FxgGuBJGSzyOxotFG4LoO5X+M1350zmPA==}
+  /@esbuild/linux-x64@0.19.12:
+    resolution: {integrity: sha512-B71g1QpxfwBvNrfyJdVDexenDIt1CiDN1TIXLbhOw0KhJzE78KIFGX6OJ9MrtC0oOqMWf+0xop4qEU8JrJTwCg==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [linux]
@@ -575,8 +575,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/netbsd-x64@0.19.11:
-    resolution: {integrity: sha512-13jvrQZJc3P230OhU8xgwUnDeuC/9egsjTkXN49b3GcS5BKvJqZn86aGM8W9pd14Kd+u7HuFBMVtrNGhh6fHEQ==}
+  /@esbuild/netbsd-x64@0.19.12:
+    resolution: {integrity: sha512-3ltjQ7n1owJgFbuC61Oj++XhtzmymoCihNFgT84UAmJnxJfm4sYCiSLTXZtE00VWYpPMYc+ZQmB6xbSdVh0JWA==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [netbsd]
@@ -584,8 +584,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/openbsd-x64@0.19.11:
-    resolution: {integrity: sha512-ysyOGZuTp6SNKPE11INDUeFVVQFrhcNDVUgSQVDzqsqX38DjhPEPATpid04LCoUr2WXhQTEZ8ct/EgJCUDpyNw==}
+  /@esbuild/openbsd-x64@0.19.12:
+    resolution: {integrity: sha512-RbrfTB9SWsr0kWmb9srfF+L933uMDdu9BIzdA7os2t0TXhCRjrQyCeOt6wVxr79CKD4c+p+YhCj31HBkYcXebw==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [openbsd]
@@ -593,8 +593,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/sunos-x64@0.19.11:
-    resolution: {integrity: sha512-Hf+Sad9nVwvtxy4DXCZQqLpgmRTQqyFyhT3bZ4F2XlJCjxGmRFF0Shwn9rzhOYRB61w9VMXUkxlBy56dk9JJiQ==}
+  /@esbuild/sunos-x64@0.19.12:
+    resolution: {integrity: sha512-HKjJwRrW8uWtCQnQOz9qcU3mUZhTUQvi56Q8DPTLLB+DawoiQdjsYq+j+D3s9I8VFtDr+F9CjgXKKC4ss89IeA==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [sunos]
@@ -602,8 +602,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/win32-arm64@0.19.11:
-    resolution: {integrity: sha512-0P58Sbi0LctOMOQbpEOvOL44Ne0sqbS0XWHMvvrg6NE5jQ1xguCSSw9jQeUk2lfrXYsKDdOe6K+oZiwKPilYPQ==}
+  /@esbuild/win32-arm64@0.19.12:
+    resolution: {integrity: sha512-URgtR1dJnmGvX864pn1B2YUYNzjmXkuJOIqG2HdU62MVS4EHpU2946OZoTMnRUHklGtJdJZ33QfzdjGACXhn1A==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [win32]
@@ -611,8 +611,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/win32-ia32@0.19.11:
-    resolution: {integrity: sha512-6YOrWS+sDJDmshdBIQU+Uoyh7pQKrdykdefC1avn76ss5c+RN6gut3LZA4E2cH5xUEp5/cA0+YxRaVtRAb0xBg==}
+  /@esbuild/win32-ia32@0.19.12:
+    resolution: {integrity: sha512-+ZOE6pUkMOJfmxmBZElNOx72NKpIa/HFOMGzu8fqzQJ5kgf6aTGrcJaFsNiVMH4JKpMipyK+7k0n2UXN7a8YKQ==}
     engines: {node: '>=12'}
     cpu: [ia32]
     os: [win32]
@@ -620,8 +620,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/win32-x64@0.19.11:
-    resolution: {integrity: sha512-vfkhltrjCAb603XaFhqhAF4LGDi2M4OrCRrFusyQ+iTLQ/o60QQXxc9cZC/FFpihBI9N1Grn6SMKVJ4KP7Fuiw==}
+  /@esbuild/win32-x64@0.19.12:
+    resolution: {integrity: sha512-T1QyPSDCyMXaO3pzBkF96E8xMkiRYbUEZADd29SyPGabqxMViNoii+NcK7eWJAEoU6RZyEm5lVSIjTmcdoB9HA==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [win32]
@@ -730,7 +730,7 @@ packages:
   /@manypkg/find-root@1.1.0:
     resolution: {integrity: sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==}
     dependencies:
-      '@babel/runtime': 7.23.8
+      '@babel/runtime': 7.23.9
       '@types/node': 12.20.55
       find-up: 4.1.0
       fs-extra: 8.1.0
@@ -739,7 +739,7 @@ packages:
   /@manypkg/get-packages@1.1.3:
     resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
     dependencies:
-      '@babel/runtime': 7.23.8
+      '@babel/runtime': 7.23.9
       '@changesets/types': 4.1.0
       '@manypkg/find-root': 1.1.0
       fs-extra: 8.1.0
@@ -747,24 +747,24 @@ packages:
       read-yaml-file: 1.1.0
     dev: true
 
-  /@microsoft/api-extractor-model@7.28.3(@types/node@20.11.5):
+  /@microsoft/api-extractor-model@7.28.3(@types/node@20.11.8):
     resolution: {integrity: sha512-wT/kB2oDbdZXITyDh2SQLzaWwTOFbV326fP0pUwNW00WeliARs0qjmXBWmGWardEzp2U3/axkO3Lboqun6vrig==}
     dependencies:
       '@microsoft/tsdoc': 0.14.2
       '@microsoft/tsdoc-config': 0.16.2
-      '@rushstack/node-core-library': 3.62.0(@types/node@20.11.5)
+      '@rushstack/node-core-library': 3.62.0(@types/node@20.11.8)
     transitivePeerDependencies:
       - '@types/node'
     dev: true
 
-  /@microsoft/api-extractor@7.39.0(@types/node@20.11.5):
+  /@microsoft/api-extractor@7.39.0(@types/node@20.11.8):
     resolution: {integrity: sha512-PuXxzadgnvp+wdeZFPonssRAj/EW4Gm4s75TXzPk09h3wJ8RS3x7typf95B4vwZRrPTQBGopdUl+/vHvlPdAcg==}
     hasBin: true
     dependencies:
-      '@microsoft/api-extractor-model': 7.28.3(@types/node@20.11.5)
+      '@microsoft/api-extractor-model': 7.28.3(@types/node@20.11.8)
       '@microsoft/tsdoc': 0.14.2
       '@microsoft/tsdoc-config': 0.16.2
-      '@rushstack/node-core-library': 3.62.0(@types/node@20.11.5)
+      '@rushstack/node-core-library': 3.62.0(@types/node@20.11.8)
       '@rushstack/rig-package': 0.5.1
       '@rushstack/ts-command-line': 4.17.1
       colors: 1.2.5
@@ -808,7 +808,7 @@ packages:
     engines: {node: '>= 8'}
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
-      fastq: 1.16.0
+      fastq: 1.17.0
     dev: true
 
   /@pkgr/core@0.1.1:
@@ -938,11 +938,11 @@ packages:
     dev: true
     optional: true
 
-  /@rushstack/eslint-patch@1.7.0:
-    resolution: {integrity: sha512-Jh4t/593gxs0lJZ/z3NnasKlplXT2f+4y/LZYuaKZW5KAaiVFL/fThhs+17EbUd53jUVJ0QudYCBGbN/psvaqg==}
+  /@rushstack/eslint-patch@1.7.2:
+    resolution: {integrity: sha512-RbhOOTCNoCrbfkRyoXODZp75MlpiHMgbE5MEBZAnnnLyQNgrigEj4p0lzsMDyc1zVsJDLrivB58tgg3emX0eEA==}
     dev: true
 
-  /@rushstack/node-core-library@3.62.0(@types/node@20.11.5):
+  /@rushstack/node-core-library@3.62.0(@types/node@20.11.8):
     resolution: {integrity: sha512-88aJn2h8UpSvdwuDXBv1/v1heM6GnBf3RjEy6ZPP7UnzHNCqOHA2Ut+ScYUbXcqIdfew9JlTAe3g+cnX9xQ/Aw==}
     peerDependencies:
       '@types/node': '*'
@@ -950,7 +950,7 @@ packages:
       '@types/node':
         optional: true
     dependencies:
-      '@types/node': 20.11.5
+      '@types/node': 20.11.8
       colors: 1.2.5
       fs-extra: 7.0.1
       import-lazy: 4.0.0
@@ -1017,8 +1017,8 @@ packages:
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
     dev: true
 
-  /@types/node@20.11.5:
-    resolution: {integrity: sha512-g557vgQjUUfN76MZAN/dt1z3dzcUsimuysco0KeluHgrPdJXkP/XdAURgyO2W9fZWHRtRBiVKzKn8vyOAwlG+w==}
+  /@types/node@20.11.8:
+    resolution: {integrity: sha512-i7omyekpPTNdv4Jb/Rgqg0RU8YqLcNsI12quKSDkRXNfx7Wxdm6HhK1awT3xTgEkgxPn3bvnSpiEAc7a7Lpyow==}
     dependencies:
       undici-types: 5.26.5
     dev: true
@@ -1174,12 +1174,12 @@ packages:
       vite: ^5.0.0
       vue: ^3.2.25
     dependencies:
-      vite: 5.0.12(@types/node@20.11.5)(lightningcss@1.23.0)
+      vite: 5.0.12(@types/node@20.11.8)(lightningcss@1.23.0)
       vue: 3.4.15(typescript@5.3.3)
     dev: true
 
-  /@vitest/coverage-v8@1.2.1(vitest@1.2.1):
-    resolution: {integrity: sha512-fJEhKaDwGMZtJUX7BRcGxooGwg1Hl0qt53mVup/ZJeznhvL5EodteVnb/mcByhEcvVWbK83ZF31c7nPEDi4LOQ==}
+  /@vitest/coverage-v8@1.2.2(vitest@1.2.2):
+    resolution: {integrity: sha512-IHyKnDz18SFclIEEAHb9Y4Uxx0sPKC2VO1kdDCs1BF6Ip4S8rQprs971zIsooLUn7Afs71GRxWMWpkCGZpRMhw==}
     peerDependencies:
       vitest: ^1.0.0
     dependencies:
@@ -1196,58 +1196,58 @@ packages:
       std-env: 3.7.0
       test-exclude: 6.0.0
       v8-to-istanbul: 9.2.0
-      vitest: 1.2.1(@types/node@20.11.5)(@vitest/ui@1.2.1)(happy-dom@13.2.1)
+      vitest: 1.2.2(@types/node@20.11.8)(@vitest/ui@1.2.2)(happy-dom@13.3.1)
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@vitest/expect@1.2.1:
-    resolution: {integrity: sha512-/bqGXcHfyKgFWYwIgFr1QYDaR9e64pRKxgBNWNXPefPFRhgm+K3+a/dS0cUGEreWngets3dlr8w8SBRw2fCfFQ==}
+  /@vitest/expect@1.2.2:
+    resolution: {integrity: sha512-3jpcdPAD7LwHUUiT2pZTj2U82I2Tcgg2oVPvKxhn6mDI2On6tfvPQTjAI4628GUGDZrCm4Zna9iQHm5cEexOAg==}
     dependencies:
-      '@vitest/spy': 1.2.1
-      '@vitest/utils': 1.2.1
+      '@vitest/spy': 1.2.2
+      '@vitest/utils': 1.2.2
       chai: 4.4.1
     dev: true
 
-  /@vitest/runner@1.2.1:
-    resolution: {integrity: sha512-zc2dP5LQpzNzbpaBt7OeYAvmIsRS1KpZQw4G3WM/yqSV1cQKNKwLGmnm79GyZZjMhQGlRcSFMImLjZaUQvNVZQ==}
+  /@vitest/runner@1.2.2:
+    resolution: {integrity: sha512-JctG7QZ4LSDXr5CsUweFgcpEvrcxOV1Gft7uHrvkQ+fsAVylmWQvnaAr/HDp3LAH1fztGMQZugIheTWjaGzYIg==}
     dependencies:
-      '@vitest/utils': 1.2.1
+      '@vitest/utils': 1.2.2
       p-limit: 5.0.0
       pathe: 1.1.2
     dev: true
 
-  /@vitest/snapshot@1.2.1:
-    resolution: {integrity: sha512-Tmp/IcYEemKaqAYCS08sh0vORLJkMr0NRV76Gl8sHGxXT5151cITJCET20063wk0Yr/1koQ6dnmP6eEqezmd/Q==}
+  /@vitest/snapshot@1.2.2:
+    resolution: {integrity: sha512-SmGY4saEw1+bwE1th6S/cZmPxz/Q4JWsl7LvbQIky2tKE35US4gd0Mjzqfr84/4OD0tikGWaWdMja/nWL5NIPA==}
     dependencies:
       magic-string: 0.30.5
       pathe: 1.1.2
       pretty-format: 29.7.0
     dev: true
 
-  /@vitest/spy@1.2.1:
-    resolution: {integrity: sha512-vG3a/b7INKH7L49Lbp0IWrG6sw9j4waWAucwnksPB1r1FTJgV7nkBByd9ufzu6VWya/QTvQW4V9FShZbZIB2UQ==}
+  /@vitest/spy@1.2.2:
+    resolution: {integrity: sha512-k9Gcahssw8d7X3pSLq3e3XEu/0L78mUkCjivUqCQeXJm9clfXR/Td8+AP+VC1O6fKPIDLcHDTAmBOINVuv6+7g==}
     dependencies:
       tinyspy: 2.2.0
     dev: true
 
-  /@vitest/ui@1.2.1(vitest@1.2.1):
-    resolution: {integrity: sha512-5kyEDpH18TB13Keutk5VScWG+LUDfPJOL2Yd1hqX+jv6+V74tp4ZYcmTgx//WDngiZA5PvX3qCHQ5KrhGzPbLg==}
+  /@vitest/ui@1.2.2(vitest@1.2.2):
+    resolution: {integrity: sha512-CG+5fa8lyoBr+9i+UZGS31Qw81v33QlD10uecHxN2CLJVN+jLnqx4pGzGvFFeJ7jSnUCT0AlbmVWY6fU6NJZmw==}
     peerDependencies:
       vitest: ^1.0.0
     dependencies:
-      '@vitest/utils': 1.2.1
+      '@vitest/utils': 1.2.2
       fast-glob: 3.3.2
       fflate: 0.8.1
       flatted: 3.2.9
       pathe: 1.1.2
       picocolors: 1.0.0
       sirv: 2.0.4
-      vitest: 1.2.1(@types/node@20.11.5)(@vitest/ui@1.2.1)(happy-dom@13.2.1)
+      vitest: 1.2.2(@types/node@20.11.8)(@vitest/ui@1.2.2)(happy-dom@13.3.1)
     dev: true
 
-  /@vitest/utils@1.2.1:
-    resolution: {integrity: sha512-bsH6WVZYe/J2v3+81M5LDU8kW76xWObKIURpPrOXm2pjBniBu2MERI/XP60GpS4PHU3jyK50LUutOwrx4CyHUg==}
+  /@vitest/utils@1.2.2:
+    resolution: {integrity: sha512-WKITBHLsBHlpjnDQahr+XK6RE7MiAsgrIkr0pGhQ9ygoxBfUeG0lUG5iLlzqjmKSlBv3+j5EGsriBzh+C3Tq9g==}
     dependencies:
       diff-sequences: 29.6.3
       estree-walker: 3.0.3
@@ -1277,7 +1277,7 @@ packages:
   /@vue/compiler-core@3.4.15:
     resolution: {integrity: sha512-XcJQVOaxTKCnth1vCxEChteGuwG6wqnUHxAm1DO3gCz0+uXKaJNx8/digSz4dLALCy8n2lKq24jSUs8segoqIw==}
     dependencies:
-      '@babel/parser': 7.23.6
+      '@babel/parser': 7.23.9
       '@vue/shared': 3.4.15
       entities: 4.5.0
       estree-walker: 2.0.2
@@ -1292,7 +1292,7 @@ packages:
   /@vue/compiler-sfc@3.4.15:
     resolution: {integrity: sha512-LCn5M6QpkpFsh3GQvs2mJUOAlBQcCco8D60Bcqmf3O3w5a+KWS5GvYbrrJBkgvL1BDnTp+e8q0lXCLgHhKguBA==}
     dependencies:
-      '@babel/parser': 7.23.6
+      '@babel/parser': 7.23.9
       '@vue/compiler-core': 3.4.15
       '@vue/compiler-dom': 3.4.15
       '@vue/compiler-ssr': 3.4.15
@@ -1338,7 +1338,7 @@ packages:
       eslint: 8.56.0
       eslint-plugin-vue: 9.20.1(eslint@8.56.0)
       typescript: 5.3.3
-      vue-eslint-parser: 9.4.1(eslint@8.56.0)
+      vue-eslint-parser: 9.4.2(eslint@8.56.0)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -2289,35 +2289,35 @@ packages:
       is-symbol: 1.0.4
     dev: true
 
-  /esbuild@0.19.11:
-    resolution: {integrity: sha512-HJ96Hev2hX/6i5cDVwcqiJBBtuo9+FeIJOtZ9W1kA5M6AMJRHUZlpYZ1/SbEwtO0ioNAW8rUooVpC/WehY2SfA==}
+  /esbuild@0.19.12:
+    resolution: {integrity: sha512-aARqgq8roFBj054KvQr5f1sFu0D65G+miZRCuJyJ0G13Zwx7vRar5Zhn2tkQNzIXcBrNVsv/8stehpj+GAjgbg==}
     engines: {node: '>=12'}
     hasBin: true
     requiresBuild: true
     optionalDependencies:
-      '@esbuild/aix-ppc64': 0.19.11
-      '@esbuild/android-arm': 0.19.11
-      '@esbuild/android-arm64': 0.19.11
-      '@esbuild/android-x64': 0.19.11
-      '@esbuild/darwin-arm64': 0.19.11
-      '@esbuild/darwin-x64': 0.19.11
-      '@esbuild/freebsd-arm64': 0.19.11
-      '@esbuild/freebsd-x64': 0.19.11
-      '@esbuild/linux-arm': 0.19.11
-      '@esbuild/linux-arm64': 0.19.11
-      '@esbuild/linux-ia32': 0.19.11
-      '@esbuild/linux-loong64': 0.19.11
-      '@esbuild/linux-mips64el': 0.19.11
-      '@esbuild/linux-ppc64': 0.19.11
-      '@esbuild/linux-riscv64': 0.19.11
-      '@esbuild/linux-s390x': 0.19.11
-      '@esbuild/linux-x64': 0.19.11
-      '@esbuild/netbsd-x64': 0.19.11
-      '@esbuild/openbsd-x64': 0.19.11
-      '@esbuild/sunos-x64': 0.19.11
-      '@esbuild/win32-arm64': 0.19.11
-      '@esbuild/win32-ia32': 0.19.11
-      '@esbuild/win32-x64': 0.19.11
+      '@esbuild/aix-ppc64': 0.19.12
+      '@esbuild/android-arm': 0.19.12
+      '@esbuild/android-arm64': 0.19.12
+      '@esbuild/android-x64': 0.19.12
+      '@esbuild/darwin-arm64': 0.19.12
+      '@esbuild/darwin-x64': 0.19.12
+      '@esbuild/freebsd-arm64': 0.19.12
+      '@esbuild/freebsd-x64': 0.19.12
+      '@esbuild/linux-arm': 0.19.12
+      '@esbuild/linux-arm64': 0.19.12
+      '@esbuild/linux-ia32': 0.19.12
+      '@esbuild/linux-loong64': 0.19.12
+      '@esbuild/linux-mips64el': 0.19.12
+      '@esbuild/linux-ppc64': 0.19.12
+      '@esbuild/linux-riscv64': 0.19.12
+      '@esbuild/linux-s390x': 0.19.12
+      '@esbuild/linux-x64': 0.19.12
+      '@esbuild/netbsd-x64': 0.19.12
+      '@esbuild/openbsd-x64': 0.19.12
+      '@esbuild/sunos-x64': 0.19.12
+      '@esbuild/win32-arm64': 0.19.12
+      '@esbuild/win32-ia32': 0.19.12
+      '@esbuild/win32-x64': 0.19.12
     dev: true
 
   /escalade@3.1.1:
@@ -2538,7 +2538,7 @@ packages:
       nth-check: 2.1.1
       postcss-selector-parser: 6.0.15
       semver: 7.5.4
-      vue-eslint-parser: 9.4.1(eslint@8.56.0)
+      vue-eslint-parser: 9.4.2(eslint@8.56.0)
       xml-name-validator: 4.0.0
     transitivePeerDependencies:
       - supports-color
@@ -2753,8 +2753,8 @@ packages:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
     dev: true
 
-  /fastq@1.16.0:
-    resolution: {integrity: sha512-ifCoaXsDrsdkWTtiNJX5uzHDsrck5TzfKKDcuFFTIrrc/BS076qgEIfoIy1VeZqViznfKiysPYTh/QeHtnIsYA==}
+  /fastq@1.17.0:
+    resolution: {integrity: sha512-zGygtijUMT7jnk3h26kUms3BkSDp4IfIKjmnqI2tvx6nuBfiF1UqOxbnLfzdv+apBy+53oaImsKtMw/xYbW+1w==}
     dependencies:
       reusify: 1.0.4
     dev: true
@@ -3000,8 +3000,8 @@ packages:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
     dev: true
 
-  /happy-dom@13.2.1:
-    resolution: {integrity: sha512-AwSV0OPsLxOu1nsKsw+1aakYGiCgLcYed/BPLMGe4lOxAZY14UWGAw8nB7SSnHRltBPwcM6Rf+5hcMXcU7qxaQ==}
+  /happy-dom@13.3.1:
+    resolution: {integrity: sha512-KIlztn+nRWstprUyI3Wzy1UJrg72uOaoo4SaBLNrV6xrn2Rq86eQruKOL7ZyDhkfou3nEZX6rgRYtvsqwMInvQ==}
     engines: {node: '>=16.0.0'}
     dependencies:
       entities: 4.5.0
@@ -3515,8 +3515,8 @@ packages:
       minimist: 1.2.8
     dev: true
 
-  /jsonc-parser@3.2.0:
-    resolution: {integrity: sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==}
+  /jsonc-parser@3.2.1:
+    resolution: {integrity: sha512-AilxAyFOAcK5wA1+LeaySVBrHsGQvUFCDWXKpZjzaL0PqW+xfBOttn8GNtWKFWqneyMZj41MWF9Kl6iPWLwgOA==}
     dev: true
 
   /jsonfile@4.0.0:
@@ -3764,8 +3764,8 @@ packages:
   /magicast@0.3.3:
     resolution: {integrity: sha512-ZbrP1Qxnpoes8sz47AM0z08U+jW6TyRgZzcWy3Ma3vDhJttwMwAFDMMQFobwdBxByBD46JYmxRzeF7w2+wJEuw==}
     dependencies:
-      '@babel/parser': 7.23.6
-      '@babel/types': 7.23.6
+      '@babel/parser': 7.23.9
+      '@babel/types': 7.23.9
       source-map-js: 1.0.2
     dev: true
 
@@ -4255,7 +4255,7 @@ packages:
   /pkg-types@1.0.3:
     resolution: {integrity: sha512-nN7pYi0AQqJnoLPC9eHFQ8AcyaixBUOwvqc5TDnIKCMEE6I0y8P7OKA7fPexsXGCGxQDl/cmrLAp26LhcwxZ4A==}
     dependencies:
-      jsonc-parser: 3.2.0
+      jsonc-parser: 3.2.1
       mlly: 1.5.0
       pathe: 1.1.2
     dev: true
@@ -4807,14 +4807,14 @@ packages:
       spdx-license-ids: 3.0.16
     dev: true
 
-  /spdx-exceptions@2.3.0:
-    resolution: {integrity: sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==}
+  /spdx-exceptions@2.4.0:
+    resolution: {integrity: sha512-hcjppoJ68fhxA/cjbN4T8N6uCUejN8yFw69ttpqtBeCbF3u13n7mb31NB9jKwGTTWWnt9IbRA/mf1FprYS8wfw==}
     dev: true
 
   /spdx-expression-parse@3.0.1:
     resolution: {integrity: sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==}
     dependencies:
-      spdx-exceptions: 2.3.0
+      spdx-exceptions: 2.4.0
       spdx-license-ids: 3.0.16
     dev: true
 
@@ -5310,8 +5310,8 @@ packages:
     engines: {node: '>= 0.10'}
     dev: true
 
-  /vite-node@1.2.1(@types/node@20.11.5):
-    resolution: {integrity: sha512-fNzHmQUSOY+y30naohBvSW7pPn/xn3Ib/uqm+5wAJQJiqQsU0NBR78XdRJb04l4bOFKjpTWld0XAfkKlrDbySg==}
+  /vite-node@1.2.2(@types/node@20.11.8):
+    resolution: {integrity: sha512-1as4rDTgVWJO3n1uHmUYqq7nsFgINQ9u+mRcXpjeOMJUmviqNKjcZB7UfRZrlM7MjYXMKpuWp5oGkjaFLnjawg==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
     dependencies:
@@ -5319,7 +5319,7 @@ packages:
       debug: 4.3.4
       pathe: 1.1.2
       picocolors: 1.0.0
-      vite: 5.0.12(@types/node@20.11.5)(lightningcss@1.23.0)
+      vite: 5.0.12(@types/node@20.11.8)(lightningcss@1.23.0)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -5331,8 +5331,8 @@ packages:
       - terser
     dev: true
 
-  /vite-plugin-dts@3.7.1(@types/node@20.11.5)(typescript@5.3.3)(vite@5.0.12):
-    resolution: {integrity: sha512-VZJckNFpVfRAkmOxhGT5OgTUVWVXxkNQqLpBUuiNGAr9HbtvmvsPLo2JB3Xhn+o/Z9+CT6YZfYa4bX9SGR5hNw==}
+  /vite-plugin-dts@3.7.2(@types/node@20.11.8)(typescript@5.3.3)(vite@5.0.12):
+    resolution: {integrity: sha512-kg//1nDA01b8rufJf4TsvYN8LMkdwv0oBYpiQi6nRwpHyue+wTlhrBiqgipdFpMnW1oOYv6ywmzE5B0vg6vSEA==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
       typescript: '*'
@@ -5341,13 +5341,13 @@ packages:
       vite:
         optional: true
     dependencies:
-      '@microsoft/api-extractor': 7.39.0(@types/node@20.11.5)
+      '@microsoft/api-extractor': 7.39.0(@types/node@20.11.8)
       '@rollup/pluginutils': 5.1.0
       '@vue/language-core': 1.8.27(typescript@5.3.3)
       debug: 4.3.4
       kolorist: 1.8.0
       typescript: 5.3.3
-      vite: 5.0.12(@types/node@20.11.5)(lightningcss@1.23.0)
+      vite: 5.0.12(@types/node@20.11.8)(lightningcss@1.23.0)
       vue-tsc: 1.8.27(typescript@5.3.3)
     transitivePeerDependencies:
       - '@types/node'
@@ -5364,12 +5364,12 @@ packages:
       svg-baker: 1.7.0
       svg-parser: 2.0.4
       svgo: 3.2.0
-      vite: 5.0.12(@types/node@20.11.5)(lightningcss@1.23.0)
+      vite: 5.0.12(@types/node@20.11.8)(lightningcss@1.23.0)
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /vite@5.0.12(@types/node@20.11.5)(lightningcss@1.23.0):
+  /vite@5.0.12(@types/node@20.11.8)(lightningcss@1.23.0):
     resolution: {integrity: sha512-4hsnEkG3q0N4Tzf1+t6NdN9dg/L3BM+q8SWgbSPnJvrgH2kgdyzfVJwbR1ic69/4uMJJ/3dqDZZE5/WwqW8U1w==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
@@ -5397,8 +5397,8 @@ packages:
       terser:
         optional: true
     dependencies:
-      '@types/node': 20.11.5
-      esbuild: 0.19.11
+      '@types/node': 20.11.8
+      esbuild: 0.19.12
       lightningcss: 1.23.0
       postcss: 8.4.33
       rollup: 4.9.6
@@ -5406,8 +5406,8 @@ packages:
       fsevents: 2.3.3
     dev: true
 
-  /vitest@1.2.1(@types/node@20.11.5)(@vitest/ui@1.2.1)(happy-dom@13.2.1):
-    resolution: {integrity: sha512-TRph8N8rnSDa5M2wKWJCMnztCZS9cDcgVTQ6tsTFTG/odHJ4l5yNVqvbeDJYJRZ6is3uxaEpFs8LL6QM+YFSdA==}
+  /vitest@1.2.2(@types/node@20.11.8)(@vitest/ui@1.2.2)(happy-dom@13.3.1):
+    resolution: {integrity: sha512-d5Ouvrnms3GD9USIK36KG8OZ5bEvKEkITFtnGv56HFaSlbItJuYr7hv2Lkn903+AvRAgSixiamozUVfORUekjw==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
     peerDependencies:
@@ -5431,19 +5431,19 @@ packages:
       jsdom:
         optional: true
     dependencies:
-      '@types/node': 20.11.5
-      '@vitest/expect': 1.2.1
-      '@vitest/runner': 1.2.1
-      '@vitest/snapshot': 1.2.1
-      '@vitest/spy': 1.2.1
-      '@vitest/ui': 1.2.1(vitest@1.2.1)
-      '@vitest/utils': 1.2.1
+      '@types/node': 20.11.8
+      '@vitest/expect': 1.2.2
+      '@vitest/runner': 1.2.2
+      '@vitest/snapshot': 1.2.2
+      '@vitest/spy': 1.2.2
+      '@vitest/ui': 1.2.2(vitest@1.2.2)
+      '@vitest/utils': 1.2.2
       acorn-walk: 8.3.2
       cac: 6.7.14
       chai: 4.4.1
       debug: 4.3.4
       execa: 8.0.1
-      happy-dom: 13.2.1
+      happy-dom: 13.3.1
       local-pkg: 0.5.0
       magic-string: 0.30.5
       pathe: 1.1.2
@@ -5452,8 +5452,8 @@ packages:
       strip-literal: 1.3.0
       tinybench: 2.6.0
       tinypool: 0.8.2
-      vite: 5.0.12(@types/node@20.11.5)(lightningcss@1.23.0)
-      vite-node: 1.2.1(@types/node@20.11.5)
+      vite: 5.0.12(@types/node@20.11.8)(lightningcss@1.23.0)
+      vite-node: 1.2.2(@types/node@20.11.8)
       why-is-node-running: 2.2.2
     transitivePeerDependencies:
       - less
@@ -5465,8 +5465,8 @@ packages:
       - terser
     dev: true
 
-  /vue-eslint-parser@9.4.1(eslint@8.56.0):
-    resolution: {integrity: sha512-EmIbJ5cCI/E06SlI8K5sldVZ+Ef5vy26Ck0lNALxgY7FEAMOjNR32qcsVM3FUJUbvVWTBEiOy5lQvbhPK/ynBw==}
+  /vue-eslint-parser@9.4.2(eslint@8.56.0):
+    resolution: {integrity: sha512-Ry9oiGmCAK91HrKMtCrKFWmSFWvYkpGglCeFAIqDdr9zdXmMMpJOmUJS7WWsW7fX81h6mwHmUZCQQ1E0PkSwYQ==}
     engines: {node: ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: '>=6.0.0'


### PR DESCRIPTION
This PR originally set out to just add some debugging UI to the `app > website`... but I made a decision about auto-suspension along the way and changed some `Earwurm` behaviour.

### Added in this PR

- New `.resume()` and `.suspend()` methods exposed on the `Earwurm` instance.
  - Allows consumers more control over their `Earwurm` state.
- New `Earwurm > play` event listener.
  - You can use this to get a `boolean` update whenever the `Earwurm` toggles between _any sound playing_ and _nothing playing_.
  - Example: `manager.on('play', (active) => console.log('is playing:', active.toString()))`.
- Added some debug UI + logic to the `app > website`.
  - Now, if you visit the `website` _(in any environment)_, you can append the `?mode=debug` param to the end of the url.
  - Example: `http://localhost:5173/earwurm/?mode=debug`

### Changed in this PR

- Removed the “timed auto-suspend” behaviour.
  - With the new `play` event, it is now easy for consumers to specify this behaviour themselves.
- While there is no more “timed auto-suspend”, the `Earwurm` will attempt to optimistically `suspend` whenever:
  - All `Stacks` have been removed from the `Earwurm`. instance.
  - `.stop()` has been called on the `Earwurn` instance.
- Will now auto-resume a `suspended` state when `.play()` is called on a `Sound`.
- Now emitting an error in the case a `.suspend()` fails.
